### PR TITLE
[정현우] 1주차 문제풀이

### DIFF
--- a/problems/week01/정현우/BOJ1021_회전하는큐.java
+++ b/problems/week01/정현우/BOJ1021_회전하는큐.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1021 회전하는 큐
+ * - 64 ms
+ * - 큐
+ * - 큐에 1 ~ N 숫자 삽입
+ * - 회전 = 큐 앞에서 숫자를 뽑고 뒤에 삽입
+ * - 원하는 숫자가 나올 때까지 회전
+ * - 회전 수와 역방향 회전했을 때의 회전 수를 비교
+ * - 역방향 회전 수 = (큐 사이즈) - (회전 수)
+ * - 더 작은 회전 수 누적
+ * */
+public class BOJ1021_회전하는큐 {
+	public static void main(String[] args) throws IOException {
+		int n;
+		int m;
+		int i;
+		int num;
+		int idx;
+		int cnt;
+		int moves;
+		BufferedReader br;
+		StringTokenizer st;
+		ArrayDeque<Integer> q;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		q = new ArrayDeque<>(n);
+		for (i = 1; i <= n; i++) { // 큐에 1 ~ N 숫자 삽입
+			q.addLast(i);
+		}
+		cnt = 0;
+		st = new StringTokenizer(br.readLine());
+		while (m-- > 0) {
+			idx = Integer.parseInt(st.nextToken());
+			moves = 0;
+			while ((num = q.pollFirst()) != idx) { // 원하는 숫자가 나올 때까지 회전
+				q.addLast(num);
+				moves++;
+			}
+			if (moves < n - moves) { // 회전 수와 역방향 회전했을 때의 회전 수를 비교
+				cnt += moves; // 더 작은 회전 수 누적
+			} else {
+				cnt += n - moves;
+			}
+			n--; // 큐 사이즈 감소
+		}
+		System.out.print(cnt);
+	}
+}

--- a/problems/week01/정현우/BOJ14501_퇴사.java
+++ b/problems/week01/정현우/BOJ14501_퇴사.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 14501 퇴사
+ * - 64 ms
+ * - DP
+ * - 1일 ~ N일 상담, N + 1일 퇴사
+ * - -> 0일 ~ N - 1일 상담, N일 퇴사
+ * - dp[i] = i일 전까지 최대 금액 합
+ * - i일의 상담을 진행하는 경우 dp[i + T] 갱신
+ * - i일의 상담을 진행하지 않는 경우 dp[i + 1] 갱신
+ * - 퇴사 전까지 최대 금액 합 dp[N]
+ */
+public class BOJ14501_퇴사 {
+	public static void main(String[] args) throws IOException {
+		int n;
+		int t;
+		int i;
+		int[] dp;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		dp = new int[n + 1]; // dp[i] = i일 전까지 최대 금액 합
+		for (i = 0; i < n; i++) { // 0일 ~ N - 1일 상담, N일 퇴사
+			st = new StringTokenizer(br.readLine());
+			t = Integer.parseInt(st.nextToken());
+			if (i + t <= n) { // i일의 상담을 진행하는 경우
+				dp[i + t] = Math.max(dp[i + t], dp[i] + Integer.parseInt(st.nextToken())); // dp[i + T] 갱신
+			}
+			dp[i + 1] = Math.max(dp[i + 1], dp[i]); // i일의 상담을 진행하지 않는 경우 dp[i + 1] 갱신
+		}
+		System.out.print(dp[n]); // 퇴사 전까지 최대 금액 합 dp[N]
+	}
+}

--- a/problems/week01/정현우/BOJ2617_구슬찾기.java
+++ b/problems/week01/정현우/BOJ2617_구슬찾기.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 2617 구슬 찾기
+ * - 112 ms
+ * - 플로이드-워셜
+ * - u보다 가벼운 v들
+ * - lighter[u][v]에 표시
+ * - u보다 무거운 v들
+ * - heavier[u][v]에 표시
+ * - u > k이고 k > v이면 u > v
+ * - u < k이고 k < v이면 u < v
+ * - lighter 또는 heavier에 표시된 개수가
+ * - N / 2를 초과하면 중간이 될 수 없는 구슬
+ * */
+public class BOJ2617_구슬찾기 {
+	public static void main(String[] args) throws IOException {
+		int n;
+		int m;
+		int u;
+		int v;
+		int k;
+		int mid;
+		int ans;
+		int lighterCnt;
+		int heavierCnt;
+		boolean[][] lighter;
+		boolean[][] heavier;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		lighter = new boolean[n + 1][n + 1]; // u보다 가벼운 v들
+		heavier = new boolean[n + 1][n + 1]; // u보다 무거운 v들
+		while (m-- > 0) {
+			st = new StringTokenizer(br.readLine());
+			u = Integer.parseInt(st.nextToken());
+			v = Integer.parseInt(st.nextToken());
+			lighter[u][v] = true;
+			heavier[v][u] = true;
+		}
+		for (k = 1; k <= n; k++) { // 플로이드-워셜
+			for (u = 1; u <= n; u++) {
+				for (v = 1; v <= n; v++) {
+					if (lighter[u][k] && lighter[k][v]) { // u > k이고 k > v이면
+						lighter[u][v] = true; // u > v
+					}
+					if (heavier[u][k] && heavier[k][v]) { // u < k이고 k < v이면
+						heavier[u][v] = true; // u < v
+					}
+				}
+			}
+		}
+		ans = 0;
+		mid = n >> 1;
+		loop:
+		for (u = 1; u <= n; u++) {
+			lighterCnt = 0; // lighter에 표시된 개수
+			heavierCnt = 0; // heavier에 표시된 개수
+			for (v = 1; v <= n; v++) {
+				if (lighter[u][v] && ++lighterCnt > mid) { // N / 2를 초과하면
+					ans++; // 중간이 될 수 없는 구슬
+					continue loop;
+				}
+				if (heavier[u][v] && ++heavierCnt > mid) { // N / 2를 초과하면
+					ans++; // 중간이 될 수 없는 구슬
+					continue loop;
+				}
+			}
+		}
+		System.out.print(ans);
+	}
+}

--- a/problems/week01/정현우/BOJ2636_치즈.java
+++ b/problems/week01/정현우/BOJ2636_치즈.java
@@ -1,0 +1,91 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 2636 치즈
+ * - 64 ms
+ * - BFS
+ * - map 1 차원 변환
+ * - q: 지금 녹는 치즈들
+ * - q2: BFS 큐
+ * - (1, 1)에서 첫 번째 BFS 시작
+ * - q2에 위치 삽입하면서 BFS
+ * - 치즈를 만나면 다음에 녹는 치즈이므로 q에 삽입
+ * - q에 저장된 치즈들 각각에서 다음 BFS 실행
+ * */
+public class BOJ2636_치즈 {
+	private static final char CHEESE = '1';
+	private static final char WALL = '\0';
+	private static final char LINE_BREAK = '\n';
+
+	private static int qSize;
+	private static int[] d;
+	private static char[] map;
+	private static boolean[] visited;
+	private static ArrayDeque<Integer> q;
+	private static ArrayDeque<Integer> q2;
+
+	private static void bfs(int pos) {
+		int i;
+		int npos;
+
+		q2.addLast(pos);
+		while (!q2.isEmpty()) {
+			pos = q2.pollFirst();
+			for (i = 0; i < 4; i++) {
+				npos = pos + d[i];
+				if (visited[npos]) { // 이미 방문한 칸
+					continue;
+				}
+				visited[npos] = true;
+				if (map[npos] == WALL) { // 벽
+					continue;
+				}
+				if (map[npos] == CHEESE) { // 치즈를 만나면
+					q.addLast(npos); // 다음에 녹는 치즈이므로 q에 삽입
+				} else {
+					q2.addLast(npos); // q2에 위치 삽입
+				}
+			}
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		int i;
+		int row;
+		int col;
+		int size;
+		int time;
+		StringBuilder sb;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		st = new StringTokenizer(br.readLine());
+		row = Integer.parseInt(st.nextToken());
+		col = (Integer.parseInt(st.nextToken()) << 1) + 3;
+		size = (row + 2) * col;
+		map = new char[size]; // map 1 차원 변환
+		for (i = 1; i <= row; i++) {
+			br.read(map, i * col + 2, col - 4);
+			br.read();
+		}
+		d = new int[] {2, col, -2, -col};
+		visited = new boolean[size];
+		q = new ArrayDeque<>(); // q: 지금 녹는 치즈들
+		q2 = new ArrayDeque<>(); // q2: BFS 큐
+		visited[1 * col + 2] = true;
+		q.addLast(1 * col + 2); // (1, 1)에서 시작 (처음 녹는 치즈로 가정)
+		for (time = -1; !q.isEmpty(); time++) {
+			qSize = q.size(); // 지금 녹는 치즈들
+			for (i = 0; i < qSize; i++) { // q에 저장된 치즈들 각각에서
+				bfs(q.pollFirst()); // 다음 BFS 실행
+			}
+		}
+		sb = new StringBuilder();
+		System.out.print(sb.append(time).append(LINE_BREAK).append(time == 0 ? 0 : qSize).toString());
+	}
+}

--- a/problems/week01/정현우/BOJ3896_소수사이수열.java
+++ b/problems/week01/정현우/BOJ3896_소수사이수열.java
@@ -1,0 +1,80 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 3896 소수 사이 수열
+ * - 84 ms
+ * - 에라토스테네스의 체 + 이분 탐색
+ * - primes 배열에 100,000개의 소수 저장
+ * - k가 소수일 경우 0 출력
+ * - k가 소수가 아닐 경우
+ * - primes에서 k를 넘는 최소 소수 위치 이분 탐색
+ * - 소수 사이 수열 길이 = (해당 소수) - (한 칸 이전 소수)
+ * */
+public class BOJ3896_소수사이수열 {
+	private static final int FAIL = 0;
+	private static final int MAX = 1_299_710;
+	private static final int SIZE = 100_000;
+	private static final char LINE_BREAK = '\n';
+
+	private static int[] primes;
+	private static boolean[] notPrime;
+	private static BufferedReader br;
+
+	private static void initPrimes() {
+		int i;
+		int j;
+		int idx;
+
+		notPrime = new boolean[MAX];
+		primes = new int[SIZE]; // primes 배열에 100,000개의 소수 저장
+		idx = 0;
+		for (i = 2; i < MAX; i++) { // 에라토스테네스의 체
+			if (notPrime[i]) {
+				continue;
+			}
+			primes[idx++] = i;
+			for (j = i << 1; j < MAX; j += i) {
+				notPrime[j] = true;
+			}
+		}
+	}
+
+	private static int solution() throws IOException {
+		int k;
+		int left;
+		int right;
+		int mid;
+
+		k = Integer.parseInt(br.readLine());
+		if (!notPrime[k]) { // k가 소수일 경우
+			return FAIL; // 0 출력
+		}
+		left = 0;
+		right = SIZE;
+		while (left < right) { // primes에서 k를 넘는 최소 소수 위치 이분 탐색
+			mid = left + right >> 1;
+			if (primes[mid] < k) {
+				left = mid + 1;
+			} else {
+				right = mid;
+			}
+		}
+		return primes[right] - primes[right - 1]; // 소수 사이 수열 길이 = (해당 소수) - (한 칸 이전 소수)
+	}
+
+	public static void main(String[] args) throws IOException {
+		int t;
+		StringBuilder sb;
+
+		initPrimes();
+		br = new BufferedReader(new InputStreamReader(System.in));
+		t = Integer.parseInt(br.readLine());
+		sb = new StringBuilder();
+		while (t-- > 0) {
+			sb.append(solution()).append(LINE_BREAK);
+		}
+		System.out.print(sb.toString());
+	}
+}


### PR DESCRIPTION
## BOJ 14501 퇴사
- 64 ms
- DP
### 풀이
1일 ~ N일 상담, N + 1일 퇴사
-> 0일 ~ N - 1일 상담, N일 퇴사
dp[i] = i일 전까지 최대 금액 합
i일의 상담을 진행하는 경우 dp[i + T] 갱신
i일의 상담을 진행하지 않는 경우 dp[i + 1] 갱신
퇴사 전까지 최대 금액 합 dp[N]

## BOJ 1021 회전하는 큐
- 64 ms
- 큐
### 풀이
큐에 1 ~ N 숫자 삽입
회전 = 큐 앞에서 숫자를 뽑고 뒤에 삽입
원하는 숫자가 나올 때까지 회전
회전 수와 역방향 회전했을 때의 회전 수를 비교
역방향 회전 수 = (큐 사이즈) - (회전 수)
더 작은 회전 수 누적

## BOJ 3896 소수 사이 수열
- 84 ms
- 에라토스테네스의 체 + 이분 탐색
### 풀이
primes 배열에 100,000개의 소수 저장
k가 소수일 경우 0 출력
k가 소수가 아닐 경우
primes에서 k를 넘는 최소 소수 위치 이분 탐색
소수 사이 수열 길이 = (해당 소수) - (한 칸 이전 소수)

## BOJ 2636 치즈
- 64 ms
- BFS
### 풀이
map 1 차원 변환
q: 지금 녹는 치즈들
q2: BFS 큐
(1, 1)에서 첫 번째 BFS 시작
q2에 위치 삽입하면서 BFS
치즈를 만나면 다음에 녹는 치즈이므로 q에 삽입
q에 저장된 치즈들 각각에서 다음 BFS 실행

## BOJ 2617 구슬 찾기
- 112 ms
- 플로이드-워셜
### 풀이
u보다 가벼운 v들
lighter[u][v]에 표시
u보다 무거운 v들
heavier[u][v]에 표시
u > k이고 k > v이면 u > v
u < k이고 k < v이면 u < v
lighter 또는 heavier에 표시된 개수가
N / 2를 초과하면 중간이 될 수 없는 구슬