### PR TITLE
[정현우] 2주차 문제풀이

### DIFF
--- a/problems/week02/정현우/BOJ1182_부분수열의합.java
+++ b/problems/week02/정현우/BOJ1182_부분수열의합.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1182 부분수열의 합
+ * - 80 ms
+ * - 비트필드 DP
+ * - 1 ~ (1 << N) - 1 비트마스크 부분집합
+ * - dp[i] = 숫자 i가 나타내는 부분집합의 숫자들의 합
+ * - dp[i] = dp[i - lowestOneBit(i)] + dp[lowestOneBit(i)]
+ * - 값이 S인 dp[i]의 개수
+ * */
+public class BOJ1182_부분수열의합 {
+    public static void main(String[] args) throws IOException {
+        int n;
+        int s;
+        int i;
+        int cnt;
+        int[] dp;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = 1 << Integer.parseInt(st.nextToken());
+        s = Integer.parseInt(st.nextToken());
+        dp = new int[n];
+        st = new StringTokenizer(br.readLine(), " ", false);
+        for (i = 1; i < n; i <<= 1) { // 1비트가 하나인 위치듫에 각 숫자 삽입
+            dp[i] = Integer.parseInt(st.nextToken());
+        }
+        cnt = 0;
+        for (i = 1; i < n; i++) { // 1 ~ (1 << N) - 1 비트마스크 부분집합
+            if ((dp[i] = dp[i ^ (i & -i)] + dp[i & -i]) == s) { // dp[i] == S 이면
+                cnt++; // 경우의 수 증가
+            } // dp[i] = dp[i - lowestOneBit(i)] + dp[lowestOneBit(i)]
+        }
+        System.out.print(cnt); // 값이 S인 dp[i]의 개수
+    }
+}

--- a/problems/week02/정현우/BOJ14503_로봇청소기.java
+++ b/problems/week02/정현우/BOJ14503_로봇청소기.java
@@ -1,0 +1,58 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 14503 로봇 청소기
+ * - 64 ms
+ * - map 1 차원 변환
+ * - 청소되지 않은 빈 칸을 찾을 때까지 반시계 회전
+ * - 청소되지 않은 빈 칸 찾으면 전진 후 청소
+ * - 못 찾으면 후진, 벽이면 작동 멈춤
+ * */
+public class BOJ14503_로봇청소기 {
+    private static final char WALL = '1';
+    private static final char EMPTY = '0';
+
+    private static int clean(int pos, int d, int[] delta, char[] map) {
+        int i;
+        int cnt;
+
+        map[pos]--; // 시작 칸 청소
+        cnt = 1; // 청소된 칸 = 1
+        for (;;) {
+            for (i = 4; i != 0 && map[pos + delta[d = (d + 3) & 3]] != EMPTY; i--); // 청소 되지 않은 빈 칸을 찾을 때까지 반시계 회전
+            if (i != 0) { // 청소되지 않은 빈 칸 찾음
+                map[pos += delta[d]]--; // 전진 후 청소
+                cnt++; // 청소된 칸 1 증가
+            } else if (map[pos += delta[(d + 2) & 3]] == WALL) { // 못 찾으면 후진, 벽이면
+                break; // 작동 멈춤
+            }
+        }
+        return cnt; // 청소된 칸
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int m;
+        int r;
+        int c;
+        int d;
+        char[] map;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken()) << 1;
+        st = new StringTokenizer(br.readLine(), " ", false);
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        d = Integer.parseInt(st.nextToken());
+        map = new char[n * m];
+        br.read(map, 0, n * m - 1); // map 1 차원 변환
+        System.out.print(clean(r * m + (c << 1), d, new int[] {-m, 2, m, -2}, map));
+    }
+}

--- a/problems/week02/정현우/BOJ15686_치킨배달.java
+++ b/problems/week02/정현우/BOJ15686_치킨배달.java
@@ -1,0 +1,134 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 15686 치킨 배달
+ * - 76 ms
+ * - DFS
+ * - Dist(치킨집, 거리) 객체 생성
+ * - dists[i][x] = Dist(j, dist)
+ * - -> 집 i와 치킨집 j 사이 거리가 dist
+ * - 각 dists[i]들을 dist 오름차순 정렬
+ * - 치킨집 선택하면서 DFS 조합
+ * - M 개의 치킨집 선택 시
+ * -   각 dists[i]들에서 가장 앞의 선택된 치킨집의 dist 합 계산
+ * - 최소값 갱신
+ * */
+public class BOJ15686_치킨배달 {
+    private static final int MAX_M = 13;
+    private static final int EMPTY = '0';
+    private static final int HOME = '1';
+    private static final int CHICKEN = '2';
+    private static final int INF = Integer.MAX_VALUE;
+
+    private static final class Dist implements Comparable<Dist> {
+        int idx;
+        int dist;
+
+        Dist(int idx, int dist) {
+            this.idx = idx;
+            this.dist = dist;
+        }
+
+        @Override
+        public int compareTo(Dist o) {
+            return Integer.compare(dist, o.dist);
+        }
+    }
+
+    private static int n;
+    private static int m;
+    private static int min;
+    private static int homeIdx;
+    private static int chickenIdx;
+    private static boolean[] selected;
+    private static Dist[][] dists;
+
+    private static int getDist(int pos1, int pos2) { // 두 좌표 사이 거리 계산
+        return Math.abs(pos1 / n - pos2 / n) + Math.abs(pos1 % n - pos2 % n);
+    }
+
+    private static void dfs(int start, int depth) {
+        int i;
+        int sum;
+
+        if (depth == m) { // M 개의 치킨집 선택 시
+            sum = 0;
+            for (i = 0; i < homeIdx; i++) { // 각 dists[i]들에서
+                for (Dist dist : dists[i]) {
+                    if (selected[dist.idx]) { // 가장 앞의 선택된 치킨집
+                        sum += dist.dist; // dist 합 계산
+                        break;
+                    }
+                }
+            }
+            if (sum < min) { // 최소값 갱신
+                min = sum;
+            }
+            return;
+        }
+        depth++;
+        for (i = start; i < chickenIdx; i++) { // DFS 조합
+            selected[i] = true; // 치킨집 선택
+            dfs(i + 1, depth); // 다음 depth
+            selected[i] = false; // 선택 해제
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        int i;
+        int j;
+        int size;
+        int home;
+        int[] homes;
+        int[] chickens;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        size = n * n;
+        homes = new int[n << 1];
+        chickens = new int[MAX_M];
+        switch (br.read()) { // (0, 0) 입력
+            case EMPTY:
+                break;
+            case HOME:
+                homes[homeIdx++] = 0;
+                break;
+            case CHICKEN:
+                chickens[chickenIdx++] = 0;
+                break;
+        }
+        for (i = 1; i < size; i++) { // (0, 1) ~ (N - 1, N - 1) 입력
+            br.read();
+            switch (br.read()) {
+                case EMPTY:
+                    break;
+                case HOME:
+                    homes[homeIdx++] = i; // 집 좌표
+                    break;
+                case CHICKEN:
+                    chickens[chickenIdx++] = i; // 치킨집 좌표
+                    break;
+            }
+        }
+        dists = new Dist[homeIdx][chickenIdx];
+        for (i = 0; i < homeIdx; i++) {
+            home = homes[i]; // 집 i
+            for (j = 0; j < chickenIdx; j++) { // 치킨집 j
+                dists[i][j] = new Dist(j, getDist(home, chickens[j])); // 집 i와 치킨집 j 사이 거리
+            }
+            Arrays.sort(dists[i]); // 각 dists[i]들을 dist 오름차순 정렬
+        }
+        min = INF;
+        selected = new boolean[chickenIdx];
+        dfs(0, 0); // DFS
+        System.out.print(min);
+    }
+}

--- a/problems/week02/정현우/BOJ17144_미세먼지안녕.java
+++ b/problems/week02/정현우/BOJ17144_미세먼지안녕.java
@@ -1,0 +1,142 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 17144 미세먼지 안녕!
+ * - 172 ms
+ * - 구현
+ * - map 1 차원 변환
+ * - 미세먼지 확산
+ * -   4방 탐색
+ * -   diff[][]에 확산값 저장 후 확산값 일괄 적용
+ * - 공기청정기 작동
+ * -   흡입구부터 배출구 까지 흡입 방향으로 한 칸씩 이동
+ * -   배출구 미세먼지 0
+ * */
+public class BOJ17144_미세먼지안녕 {
+    private static final int WALL = Integer.MAX_VALUE;
+
+    private static int r;
+    private static int c;
+    private static int ap1;
+    private static int ap2;
+    private static int thr;
+    private static int col;
+    private static int[] d;
+    private static int[] map;
+    private static int[] diff;
+
+    private static void diffuse(int pos) { // 1 칸 확산
+        int i;
+        int val;
+        int npos;
+
+        val = map[pos] / 5; // 한 칸당 확산량
+        for (i = 0; i < 4; i++) { // 4방 탐색
+            npos = pos + d[i]; // 인접 칸
+            if (map[npos] != WALL) { // 벽이 아니면
+                map[pos] -= val; // 확산
+                diff[npos] += val; // 확산값 저장
+            }
+        }
+    }
+
+    private static void diffuseAll() { // 미세먼지 확산
+        int i;
+        int j;
+
+        for (i = col + 1; i < ap1; i += col) { // 1 열 (공기청정기 위)
+            diffuse(i); // 확산
+        }
+        for (i = ap2 + col; i < thr; i += col) { // 1 열 (공기청정기 아래)
+            diffuse(i); // 확산
+        }
+        for (i = col; i < thr; i += col) { // 전체 행
+            for (j = 2; j <= c; j++) { // 2 열 ~ C 열
+                diffuse(i + j); // 확산
+            }
+        }
+        for (i = col; i < thr; i += col) { // 전체 행
+            for (j = i + 1; j <= i + c; j++) { // 전체 열
+                map[j] += diff[j]; // 확산값 적용
+                diff[j] = 0; // 확산값 초기화
+            }
+        }
+    }
+
+    private static void purify() { // 공기청정기 작동
+        int i;
+
+        for (i = ap1 - col; i > col + 1; i -= col) { // 1 열 (공기청정기 위)
+            map[i] = map[i - col];
+        }
+        System.arraycopy(map, col + 2, map, col + 1, c - 1); // 1 행
+        for (i = col + c; i < ap1; i += col) { // C 열 (공기청정기 위)
+            map[i] = map[i + col];
+        }
+        System.arraycopy(map, ap1 + 1, map, ap1 + 2, c - 2); // 공기청정기 첫 번째 행
+        map[ap1 + 1] = 0; // 공기청정기 첫 번째 배출구
+        for (i = ap2 + col; i < thr - col; i += col) { // 1 열 (공기청정기 아래)
+            map[i] = map[i + col];
+        }
+        System.arraycopy(map, r * col + 2, map, r * col + 1, c - 1); // R 행
+        for (i = r * col + c; i > ap2 + col; i -= col) { // C 열 (공기청정기 아래)
+            map[i] = map[i - col];
+        }
+        System.arraycopy(map, ap2 + 1, map, ap2 + 2, c - 2); // 공기청정기 두 번째 행
+        map[ap2 + 1] = 0; // 공기청정기 두 번째 배출구
+    }
+
+    public static void main(String[] args) throws IOException {
+        int t;
+        int i;
+        int j;
+        int cnt;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        t = Integer.parseInt(st.nextToken());
+        col = c + 2;
+        thr = (r + 1) * col;
+        map = new int[(r + 2) * col]; // map 1 차원 변환
+        for (i = 1; i <= c; i++) { // 0 행 벽
+            map[i] = WALL;
+        }
+        for (i = col; i < thr; i += col) {
+            map[i] = WALL; // 0 열 벽
+            st = new StringTokenizer(br.readLine(), " ", false);
+            map[i + 1] = Integer.parseInt(st.nextToken()); // 1 열 입력
+            if (map[i + 1] == -1) { // 공기청정기
+                map[i + 1] = WALL; // 공기청정기 벽 취급
+                ap2 = i + 1; // 공기청정기 두 번째 칸 좌표
+            }
+            for (j = 2; j <= c; j++) { // 2 열 ~ C 열 입력
+                map[i + j] = Integer.parseInt(st.nextToken());
+            }
+            map[i + c + 1] = WALL; // C + 1 열 벽
+        }
+        ap1 = ap2 - col; // 공기청정기 첫 번째 칸 좌표
+        System.arraycopy(map, 1, map, (r + 1) * col + 1, c); // R + 1 행 벽
+        diff = new int[(r + 1) * col]; // 확산값
+        d = new int[] {-col, 1, col, -1}; // 4방 탐색
+        while (t-- > 0) {
+            diffuseAll(); // 미세먼지 확산
+            purify(); // 공기청정기 작동
+        }
+        map[ap1] = 0; // 공기청정기 칸 미세먼지 0
+        map[ap2] = 0;
+        cnt = 0;
+        for (i = col; i < thr; i += col) {
+            for (j = 1; j <= c; j++) {
+                cnt += map[i + j]; // 미세먼지 합
+            }
+        }
+        System.out.print(cnt);
+    }
+}

--- a/problems/week02/정현우/BOJ17179_케이크자르기.java
+++ b/problems/week02/정현우/BOJ17179_케이크자르기.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 17179 케이크 자르기
+ * - 92 ms
+ * - 이분 탐색
+ * - Q + 1 조각을 만들 때 가장 작은 조각 길이 최대값
+ * - = Q + 1 조각을 만들 수 있는
+ * -   조각 길이 최소 한계값의 upperBound - 1
+ * - 특정 길이가 최소 한계값일 때
+ * - Q + 1 조각을 만들 수 있는지 확인하면서 이분 탐색
+ * - Q가 오름차순이므로 이전 upperBound를 right로 사용
+ * */
+public class BOJ17179_케이크자르기 {
+    private static final char LINE_BREAK = '\n';
+
+    private static int m;
+    private static int q;
+    private static int[] arr;
+
+    private static boolean validate(int thr) {
+        int i;
+        int cnt;
+        int curr;
+
+        cnt = 0; // 조각 수
+        curr = 0; // 현재 조각 길이
+        for (i = 0; i <= m; i++) {
+            curr += arr[i]; // 현재 조각 길이 누적
+            if (curr >= thr) { // 현재 조각 >= 조각 길이 최소 한계값
+                if (++cnt > q) { // 조각 생성, Q + 1 조각이면
+                    return true; // Q + 1 조각 생성 가능
+                }
+                curr = 0; // 자르기
+            }
+        }
+        return false; // Q + 1 조각 생성 불가
+    }
+
+    private static int upperBound(int right) {
+        int mid;
+        int left;
+
+        left = 0;
+        while (left < right) {
+            mid = left + right >> 1;
+            if (validate(mid)) { // mid가 조각 길이 최소 한계값일 때 Q + 1 조각 생성 가능
+                left = mid + 1;
+            } else { // mid가 조각 길이 최소 한계값일 때 Q + 1 조각 생성 불가
+                right = mid;
+            }
+        }
+        return left; // upperBound
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int l;
+        int i;
+        int prev;
+        int prefix;
+        StringBuilder sb;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        l = Integer.parseInt(st.nextToken());
+        arr = new int[m + 1];
+        prefix = 0;
+        for (i = 0; i < m; i++) {
+            arr[i] = Integer.parseInt(br.readLine()) - prefix; // 지점과 지점 사이 길이
+            prefix += arr[i]; // 누적합
+        }
+        arr[m] = l - prefix; // 마지막 지점과 케이크 끝 사이 길이
+        sb = new StringBuilder();
+        prev = l + 1; // 초기 right값 = 케이크 길이 + 1
+        while (n-- > 0) {
+            q = Integer.parseInt(br.readLine()); // Q 값
+            prev = upperBound(prev); // Q가 오름차순이므로 이전 upperBound를 right로 사용
+            sb.append(prev - 1).append(LINE_BREAK); // upperBound - 1
+        }
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## [BOJ 17144 미세먼지 안녕!](https://github.com/Algo-Study-2409/algo-study-2409/commit/01bb86c8ae14a9c53af9ffc72c4eb8d33e62fb78) 
- 172 ms
- 시뮬레이션
### 풀이
map 1 차원 변환
미세먼지 확산
&nbsp;&nbsp;4방 탐색
&nbsp;&nbsp;diff[][]에 확산값 저장 후 확산값 일괄 적용
공기청정기 작동
&nbsp;&nbsp;흡입구부터 배출구 까지 흡입 방향으로 한 칸씩 이동
&nbsp;&nbsp;배출구 미세먼지 0

## [BOJ 15686 치킨 배달](https://github.com/Algo-Study-2409/algo-study-2409/commit/83d0fe26771bd55944f5bb9fcbd41440d938a28e) 
- 76 ms
- DFS
### 풀이
Dist(치킨집, 거리) 객체 생성
dists[i][x] = Dist(j, dist)
-> 집 i와 치킨집 j 사이 거리가 dist
각 dists[i]들을 dist 오름차순 정렬
치킨집 선택하면서 DFS 조합
M 개의 치킨집 선택 시
&nbsp;&nbsp;각 dists[i]들에서 가장 앞의 선택된 치킨집의 dist 합 계산
최소값 갱신

## [BOJ 14503 로봇 청소기](https://github.com/Algo-Study-2409/algo-study-2409/commit/1914e67275472cd860cf1b2f177e1b1599aba9c4) 
- 64 ms
- 시뮬레이션
### 풀이
map 1 차원 변환
청소되지 않은 빈 칸을 찾을 때까지 반시계 회전
청소되지 않은 빈 칸 찾으면 전진 후 청소
못 찾으면 후진, 벽이면 작동 멈춤

## [BOJ 1182 부분수열의 합](https://github.com/Algo-Study-2409/algo-study-2409/commit/e304367674b809ace5f1c4733124cd28933762d0) 
- 80 ms
- 비트필드 DP
### 풀이
1 ~ (1 << N) - 1 비트마스크 부분집합
dp[i] = 숫자 i가 나타내는 부분집합의 숫자들의 합
dp[i] = dp[i - lowestOneBit(i)] + dp[lowestOneBit(i)]
값이 S인 dp[i]의 개수

## [BOJ 17179 케이크 자르기](https://github.com/Algo-Study-2409/algo-study-2409/commit/1bed121cdc9cb46486e86e66857185b8d9979d55) 
- 92 ms
- 이분 탐색
### 풀이
Q + 1 조각을 만들 때 가장 작은 조각 길이 최대값
= Q + 1 조각을 만들 수 있는
&nbsp;&nbsp;조각 길이 최소 한계값의 upperBound - 1
특정 길이가 최소 한계값일 때
Q + 1 조각을 만들 수 있는지 확인하면서 이분 탐색
Q가 오름차순이므로 이전 upperBound를 right로 사용