### PR TITLE
[정현우] 3주차 문제풀이

### DIFF
--- a/problems/week03/정현우/BOJ1260_DFS와BFS.java
+++ b/problems/week03/정현우/BOJ1260_DFS와BFS.java
@@ -1,0 +1,114 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1260 DFS와 BFS
+ * - 120 ms
+ * - DFS + BFS
+ * - 양방향 간선 입력
+ * - 노드 별 Linked List 생성
+ * - 정렬을 유지할 수 있는 위치에 간선 삽입
+ * - DFS, BFS 방문하면서 출력
+ * */
+public class BOJ1260_DFS와BFS {
+	private static final int MAX_N = 1_000;
+	private static final char SPACE = ' ';
+	private static final char LINE_BREAK = '\n';
+	private static final Edge NIL = new Edge(Integer.MAX_VALUE, null);
+
+	private static final class Edge {
+		int to;
+		Edge next;
+
+		Edge(int to, Edge next) {
+			this.to = to;
+			this.next = next;
+		}
+	}
+
+	private static boolean[] visited;
+	private static Edge[] adj;
+	private static StringBuilder sb;
+
+	private static final void addEdge(int u, int v) {
+		Edge edge;
+
+		for (edge = adj[u]; edge.next.to < v; edge = edge.next); // 정렬을 유지할 수 있는 위치 탐색
+		edge.next = new Edge(v, edge.next); // Linked List 중간에 삽입
+	}
+
+	private static final void dfs(int curr) { // DFS
+		int to;
+		Edge edge;
+
+		for (edge = adj[curr].next; edge != NIL; edge = edge.next) { // head, tail 제외하고 탐색
+			if (!visited[to = edge.to]) { // 방문 되지 않은 노드
+				sb.append(to).append(SPACE); // 방문할 노드 출력
+				visited[to] = true; // 방문 처리
+				dfs(to); // 방문
+			}
+		}
+	}
+
+	private static final void bfs(int start) {
+		int to;
+		int curr;
+		Edge edge;
+		ArrayDeque<Integer> q;
+
+		q = new ArrayDeque<>(MAX_N);
+		sb.append(start).append(SPACE); // 시작 노드 출력
+		visited[start] = true; // 시작 노드 방문 처리
+		q.addLast(start); // 시작 노드 큐에 삽입
+		while (!q.isEmpty()) {
+			curr = q.pollFirst();
+			for (edge = adj[curr].next; edge != NIL; edge = edge.next) { // head, tail 제외하고 탐색
+				if (!visited[to = edge.to]) { // 방문 되지 않은 노드
+					sb.append(to).append(SPACE); // 방문할 노드 출력
+					visited[to] = true; // 방문 처리
+					q.addLast(to); // 큐에 삽입
+				}
+			}
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		int n;
+		int m;
+		int v;
+		int v1;
+		int v2;
+		int i;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		st = new StringTokenizer(br.readLine(), " ", false);
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		v = Integer.parseInt(st.nextToken());
+		adj = new Edge[n + 1];
+		for (i = 1; i <= n; i++) { // 노드 별 Linked List 생성
+			adj[i] = new Edge(0, NIL); // head.to = 0, tail.to = INF
+		}
+		while (m-- > 0) {
+			st = new StringTokenizer(br.readLine(), " ", false);
+			v1 = Integer.parseInt(st.nextToken());
+			v2 = Integer.parseInt(st.nextToken());
+			addEdge(v1, v2); // 정방향 간선 삽입
+			addEdge(v2, v1); // 역방향 간선 삽입
+		}
+		sb = new StringBuilder();
+		visited = new boolean[n + 1];
+		sb.append(v).append(SPACE); // 시작 노드 출력
+		visited[v] = true; // 시작 노드 방문 처리
+		dfs(v); // DFS
+		sb.append(LINE_BREAK);
+		visited = new boolean[n + 1]; // 방문 배열 초기화
+		bfs(v); // BFS
+		System.out.print(sb.toString());
+	}
+}

--- a/problems/week03/정현우/BOJ13975_파일합치기3.java
+++ b/problems/week03/정현우/BOJ13975_파일합치기3.java
@@ -1,0 +1,91 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 13975 파일 합치기 3
+ * - 868 ms
+ * - 그리디 + 세그먼트 트리
+ * - K 개 이상의 리프 노드를 갖는
+ * - 최소값 Bottom-Up 세그트리 구성
+ * - 값 = (파일 크기) << 21 | (리프 인덱스)
+ * - 최소값 삭제 (파일 크기 INF로 대체)
+ * - cost = 기존 최소값과 새로운 최소값의 파일 크기 합
+ * - 새로운 최소값 파일 크기 cost로 대체
+ * - cost 합 출력
+ * */
+public class BOJ13975_파일합치기3 {
+	private static final int MAX_SIZE = 2_097_152;
+	private static final int SHIFT = 21;
+	private static final long MOD = (1 << SHIFT) - 1;
+	private static final long INF = 10_000_000_001L;
+	private static final long INIT = INF << SHIFT;
+	private static final char LINE_BREAK = '\n';
+
+	private static int leaf;
+	private static long[] tree;
+	private static BufferedReader br;
+
+	private static final void init(int k) throws IOException {
+		int i;
+		int thr;
+		int size;
+		StringTokenizer st;
+
+		for (leaf = 1; leaf < k; leaf <<= 1); // 리프 노드 시작 인덱스
+		size = leaf << 1; // 트리 크기
+		st = new StringTokenizer(br.readLine());
+		thr = leaf + k;
+		for (i = leaf; i < thr; i++) { // K 개 리프에 (파일 크기) << 21 | (리프 인덱스) 입력
+			tree[i] = Long.parseLong(st.nextToken()) << SHIFT | i;
+		}
+		for (; i < size; i++) { // 나머지 리프 INF << 21 으로 초기화
+			tree[i] = INIT;
+		}
+		for (i = leaf - 1; i > 0; i--) { // 최소값 세그먼트 트리 구성
+			tree[i] = Math.min(tree[i << 1], tree[i << 1 | 1]);
+		}
+	}
+
+	private static final void alter(long val) {
+		int i;
+
+		i = (int) (tree[1] & MOD); // 최소값의 리프 인덱스
+		tree[i] = val << SHIFT | i; // (대체할 파일 크기) << 21 | (리프 인덱스)
+		for (i >>= 1; i > 0; i >>= 1) { // 리프에서 루트까지 최소값 업데이트
+			tree[i] = Math.min(tree[i << 1], tree[i << 1 | 1]);
+		}
+	}
+
+	private static final long solution() throws IOException {
+		int k;
+		long sum;
+		long cost;
+
+		k = Integer.parseInt(br.readLine());
+		init(k); // 세그트리 초기화
+		sum = 0; // cost 합
+		while (--k > 0) { // k - 1 회 합치면 최종 파일 완성
+			cost = tree[1] >> SHIFT; // 최소값의 파일 크기
+			alter(INF); // 최소값 삭제 (파일 크기 INF로 대체)
+			sum += cost += tree[1] >> SHIFT; // 기존 최소값의 파일 크기 + 새로운 최소값의 파일 크기
+			alter(cost); // 새로운 최소값 파일 크기 cost로 대체
+		}
+		return sum; // cost 합 반환
+	}
+
+	public static void main(String[] args) throws IOException {
+		int t;
+		StringBuilder sb;
+
+		tree = new long[MAX_SIZE];
+		br = new BufferedReader(new InputStreamReader(System.in));
+		t = Integer.parseInt(br.readLine());
+		sb = new StringBuilder();
+		while (t-- > 0) {
+			sb.append(solution()).append(LINE_BREAK);
+		}
+		System.out.print(sb.toString());
+	}
+}

--- a/problems/week03/정현우/BOJ14888_연산자끼워넣기.java
+++ b/problems/week03/정현우/BOJ14888_연산자끼워넣기.java
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 14888 연산자 끼워넣기
+ * - 68 ms
+ * - DFS
+ * - 연산자별 개수를 파라미터로 DFS
+ * - 개수가 남아있는 연산자 하나씩 적용
+ * - 마지막 depth에서 최대, 최소값 갱신
+ * */
+public class BOJ14888_연산자끼워넣기 {
+	private static final int INF = Integer.MAX_VALUE;
+	private static final int MIN = Integer.MIN_VALUE;
+	private static final char LINE_BREAK = '\n';
+
+	private static int n;
+	private static int max;
+	private static int min;
+	private static int[] arr;
+
+	private static final void dfs(int depth, int num, int add, int sub, int mul, int div) {
+		if (depth == n) { // 마지막 depth
+			if (num > max) { // 최대값 갱신
+				max = num;
+			}
+			if (num < min) { // 최소값 갱신
+				min = num;
+			}
+			return;
+		}
+		depth++; // 다음 depth
+		if (add != 0) { // 덧셈
+			dfs(depth, num + arr[depth], add - 1, sub, mul, div);
+		}
+		if (sub != 0) { // 뺄셈
+			dfs(depth, num - arr[depth], add, sub - 1, mul, div);
+		}
+		if (mul != 0) { // 곱셈
+			dfs(depth, num * arr[depth], add, sub, mul - 1, div);
+		}
+		if (div != 0) { // 나눗셈
+			dfs(depth, num / arr[depth], add, sub, mul, div - 1);
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		int i;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		st = new StringTokenizer(br.readLine(), " ", false);
+		arr = new int[n];
+		for (i = 0; i < n; i++) { // 숫자 입력
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		n--; // 마지막 depth
+		max = MIN;
+		min = INF;
+		st = new StringTokenizer(br.readLine(), " ", false); // 연산자별 개수를 파라미터로 DFS
+		dfs(0, arr[0], Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));
+		System.out.print(new StringBuilder().append(max).append(LINE_BREAK).append(min));
+	}
+}

--- a/problems/week03/정현우/BOJ17298_오큰수.java
+++ b/problems/week03/정현우/BOJ17298_오큰수.java
@@ -1,0 +1,62 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 17298 오큰수
+ * - 636 ms
+ * - Deque
+ * - N + 1 크기의 Deque 생성
+ * - 입력받는 숫자들 tail에 추가
+ * - head에 INF 추가
+ * - tail에서 한 숫자씩 pollLast
+ * - head가 숫자보다 커질 때까지 pollFirst
+ * - NGE(현재 숫자의 인덱스) = peekFirst
+ * - head에 현재 숫자 삽입
+ * - NGE가 INF이면 -1
+ * */
+public class BOJ17298_오큰수 {
+	private static final int INF = Integer.MAX_VALUE;
+	private static final char SPACE = ' ';
+	private static final char[] FAIL = {'-', '1', ' '};
+
+	public static void main(String[] args) throws IOException {
+		int n;
+		int i;
+		int num;
+		int[] nge;
+		ArrayDeque<Integer> dq;
+		StringBuilder sb;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		dq = new ArrayDeque<>(n + 1);
+		st = new StringTokenizer(br.readLine(), " ", false);
+		for (i = 0; i < n; i++) { // 입력받는 숫자들 tail에 추가
+			dq.addLast(Integer.parseInt(st.nextToken()));
+		}
+		nge = new int[n];
+		dq.addFirst(INF); // head에 INF 추가
+		while (n-- > 0) {
+			num = dq.pollLast(); // tail에서 한 숫자씩 pollLast
+			while (num >= dq.peekFirst()) { // head가 숫자보다 커질 때까지 pollFirst
+				dq.pollFirst();
+			}
+			nge[n] = dq.peekFirst(); // NGE(현재 숫자의 인덱스) = peekFirst
+			dq.addFirst(num); // head에 현재 숫자 삽입
+		}
+		sb = new StringBuilder();
+		for (int ans : nge) {
+			if (ans == INF) { // NGE가 INF이면 -1
+				sb.append(FAIL);
+			} else {
+				sb.append(ans).append(SPACE);
+			}
+		}
+		System.out.print(sb.toString());
+	}
+}

--- a/problems/week03/정현우/BOJ21939_문제추천시스템Version1.java
+++ b/problems/week03/정현우/BOJ21939_문제추천시스템Version1.java
@@ -1,0 +1,146 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 21939 문제 추천 시스템 Version 1
+ * - 284 ms
+ * - 오프라인 쿼리 + Lazy 세그먼트 트리
+ * - 값 = (L << 17) | P
+ * - recommend 시점 별 최소, 최대 값 구하기
+ * - 각 시점을 리프노드로 하는 최소, 최대 값 세그먼트 트리 구성
+ * - 문제가 살아있는 시간 범위에 최소, 최대 값 업데이트
+ * - 범위 업데이트 Lazy 적용
+ * - 마지막에 모든 노드에 대해 propagate
+ * - 각 리프노드 별로 출력해야 할 최대 또는 최소 값에
+ * - (1 << 17) - 1 과 AND 연산하여 P만 출력
+ * */
+public class BOJ21939_문제추천시스템Version1 {
+	private static final int INF = Integer.MAX_VALUE >> 1;
+	private static final int MAX_P = 100_001;
+	private static final int SHIFT = 17;
+	private static final int MOD = (1 << SHIFT) - 1;
+	private static final int RECOMMEND = 9;
+	private static final int ADD = 3;
+	private static final int SOLVED = 6;
+	private static final char MAX = '1';
+	private static final char LINE_BREAK = '\n';
+
+	private static int[] maxLazy;
+	private static int[] minLazy;
+	private static char[] times;
+	private static StringBuilder sb;
+
+	private static final class Range {
+		int left; // 범위 시작
+		int right; // 범위 마지막
+		int val; // (L << 17) | P
+		Range next; // Linked List에서의 next
+
+		Range(int left, int val) {
+			this.left = left;
+			this.right = INF;
+			this.val = val;
+		}
+
+		Range(int left, int val, Range next) {
+			this.left = left;
+			this.right = INF;
+			this.val = val;
+			this.next = next;
+		}
+	}
+
+	private static final void update(int node, int start, int end, int left, int right, int val) {
+		int mid;
+
+		if (right < start || end < left) { // 업데이트 범위를 벗어나는 노드
+			return;
+		}
+		if (left <= start && end <= right) { // 업데이트 범위에 완전히 포함되는 노드
+			maxLazy[node] = Math.max(maxLazy[node], val); // 최대값 업데이트
+			minLazy[node] = Math.min(minLazy[node], val); // 최소값 업데이트
+			return; // Lazy : 하위 노드는 아직 업데이트 하지 않음
+		}
+		mid = start + end >> 1;
+		update(node << 1, start, mid, left, right, val);
+		update(node << 1 | 1, mid + 1, end, left, right, val);
+	}
+
+	private static final void prop(int node, int start, int end) {
+		int mid;
+
+		if (start == end) { // 각 리프노드 별로 출력해야 할 최대 또는 최소 값에
+			sb.append((times[start] == MAX ? maxLazy[node] : minLazy[node]) & MOD).append(LINE_BREAK);
+			return; // (1 << 17) - 1 과 AND 연산하여 P만 출력
+		}
+		maxLazy[node << 1] = Math.max(maxLazy[node], maxLazy[node << 1]); // propagate
+		maxLazy[node << 1 | 1] = Math.max(maxLazy[node], maxLazy[node << 1 | 1]); // propagate
+		minLazy[node << 1] = Math.min(minLazy[node], minLazy[node << 1]); // propagate
+		minLazy[node << 1 | 1] = Math.min(minLazy[node], minLazy[node << 1 | 1]); // propagate
+		mid = start + end >> 1;
+		prop(node << 1, start, mid);
+		prop(node << 1 | 1, mid + 1, end);
+	}
+
+	public static void main(String[] args) throws IOException {
+		int n;
+		int m;
+		int p;
+		int i;
+		int time;
+		int size;
+		Range range;
+		Range[] ranges;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		ranges = new Range[MAX_P];
+		while (n-- > 0) {
+			st = new StringTokenizer(br.readLine(), " ", false);
+			p = Integer.parseInt(st.nextToken()); // 문제 P의 범위를 [현재 시간, INF]로 설정
+			ranges[p] = new Range(0, (Integer.parseInt(st.nextToken()) << SHIFT) | p);
+		} // 값 = (L << 17) | P
+		m = Integer.parseInt(br.readLine());
+		time = 1; // 시계
+		times = new char[m + 1]; // 각 시점 별로 recommend할 값이 최대인지 최소인지 저장
+		for (i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine(), " ", false);
+			switch (st.nextToken().length()) {
+				case RECOMMEND: // recommend할 값이 최대인지 최소인지
+					times[time++] = st.nextToken().charAt(0); // 현재 시각 ++
+					break;
+				case ADD:
+					p = Integer.parseInt(st.nextToken()); // 문제 P의 범위에 [현재 시각, INF] 추가
+					ranges[p] = new Range(time, (Integer.parseInt(st.nextToken()) << SHIFT) | p, ranges[p]);
+					break; // 값 = (L << 17) | P
+				case SOLVED:
+					p = Integer.parseInt(st.nextToken()); // 문제 번호 P
+					if (ranges[p].left < time) { // 생성된 시간이 현재 시각보다 이전
+						ranges[p].right = time - 1; // 범위 끝을 현재 시각 - 1 로 설정
+					} else { // 생성 후 recommend 전에 삭제되는 문제
+						ranges[p] = ranges[p].next; // 범위 삭제
+					}
+					break;
+			}
+		}
+		size = time << 2;
+		maxLazy = new int[size];
+		minLazy = new int[size];
+		for (i = 0; i < size; i++) { // 최소값 세그트리 INF 초기화
+			minLazy[i] = INF;
+		}
+		time--; // 마지막 recommend 시각
+		for (i = 1; i < MAX_P; i++) { // 각 범위에 대해 세그먼트 트리 업데이트
+			for (range = ranges[i]; range != null; range = range.next) {
+				update(1, 1, time, range.left, range.right, range.val);
+			}
+		}
+		sb = new StringBuilder();
+		prop(1, 1, time); // 모든 노드에 대해 propagate
+		System.out.print(sb.toString());
+	}
+}


### PR DESCRIPTION
## [BOJ 13975 파일 합치기 3](https://github.com/Algo-Study-2409/algo-study-2409/commit/367b3a608ff4aa259715eb88d007173c5da080cf) 
- 868 ms
- 그리디 + 세그먼트 트리
### 풀이
K 개 이상의 리프 노드를 갖는
최소값 Bottom-Up 세그트리 구성
값 = (파일 크기) << 21 | (리프 인덱스)
최소값 삭제 (파일 크기 INF로 대체)
cost = 기존 최소값과 새로운 최소값의 파일 크기 합
새로운 최소값 파일 크기 cost로 대체
cost 합 출력

## [BOJ 1260 DFS와 BFS](https://github.com/Algo-Study-2409/algo-study-2409/commit/ffcf8738fa6b645a75836d94ec62c2db74254067) 
- 120 ms
- DFS + BFS
### 풀이
양방향 간선 입력
노드 별 Linked List 생성
정렬을 유지할 수 있는 위치에 간선 삽입
DFS, BFS 방문하면서 출력

## [BOJ 21939 문제 추천 시스템 Version 1](https://github.com/Algo-Study-2409/algo-study-2409/commit/599ba8fa50e4695b6d631f174eac6708e448f26d) 
- 284 ms
- 오프라인 쿼리 + Lazy 세그먼트 트리
### 풀이
값 = (L << 17) | P
recommend 시점 별 최소, 최대 값 구하기
각 시점을 리프노드로 하는 최소, 최대 값 세그먼트 트리 구성
문제가 살아있는 시간 범위에 최소, 최대 값 업데이트
범위 업데이트 Lazy 적용
마지막에 모든 노드에 대해 propagate
각 리프노드 별로 출력해야 할 최대 또는 최소 값에
(1 << 17) - 1 과 AND 연산하여 P만 출력

## [BOJ 14888 연산자 끼워넣기](https://github.com/Algo-Study-2409/algo-study-2409/commit/e3ab820115edc492eae884cd43868b47bbb3260c) 
- 68 ms
- DFS
### 풀이
연산자별 개수를 파라미터로 DFS
개수가 남아있는 연산자 하나씩 적용
마지막 depth에서 최대, 최소값 갱신

## [BOJ 17298 오큰수](https://github.com/Algo-Study-2409/algo-study-2409/commit/eeb35c586133ec5b6bc7cedbfece2d091da84445) 
- 636 ms
- Deque
### 풀이
N + 1 크기의 Deque 생성
입력받는 숫자들 tail에 추가
head에 INF 추가
tail에서 한 숫자씩 pollLast
head가 숫자보다 커질 때까지 pollFirst
NGE(현재 숫자의 인덱스) = peekFirst
head에 현재 숫자 삽입
NGE가 INF이면 -1