### PR TITLE
[정현우] 4주차 문제풀이

### DIFF
--- a/problems/week04/정현우/BOJ1012_유기농배추.java
+++ b/problems/week04/정현우/BOJ1012_유기농배추.java
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1012 유기농 배추
+ * - 80 ms
+ * - DFS
+ * - map 1 차원 변환
+ * - 배추 위치 map에 true로 표시
+ * - true인 지점들에서 출발
+ * - 4방 탐색 DFS 타면서 false로 표시
+ * - DFS 출발 할 때마다 카운트
+ * */
+public class BOJ1012_유기농배추 {
+	private static final int COL = 52;
+	private static final int MAX_K = 2_500;
+	private static final int[] d = {-COL, 1, COL, -1};
+	private static final char LINE_BREAK = '\n';
+
+	private static int[] positions;
+	private static boolean[] map;
+	private static BufferedReader br;
+
+	private static final void dfs(int pos) {
+		int i;
+		int npos;
+
+		map[pos] = false; // DFS 타면서 true인 지점들 false로 표시
+		for (i = 0; i < 4; i++) { // 4방 탐색
+			npos = pos + d[i];
+			if (map[npos]) {
+				dfs(npos);
+			}
+		}
+	}
+
+	private static final int solution() throws IOException {
+		int k;
+		int i;
+		int cnt;
+		StringTokenizer st;
+
+		st = new StringTokenizer(br.readLine(), " ", false);
+		st.nextToken();
+		st.nextToken();
+		k = Integer.parseInt(st.nextToken());
+		for (i = 0; i < k; i++) { // map 1 차원 변환
+			st = new StringTokenizer(br.readLine(), " ", false);
+			map[positions[i] = (Integer.parseInt(st.nextToken()) + 1) * COL + Integer.parseInt(st.nextToken()) + 1] = true;
+		} // 배추 위치 map에 true로 표시
+		cnt = 0;
+		while (k-- > 0) {
+			if (map[positions[k]]) { // true인 지점들에서 출발
+				dfs(positions[k]); // DFS
+				cnt++; // DFS 출발 할 때마다 카운트
+			}
+		}
+		return cnt;
+	}
+
+	public static void main(String[] args) throws IOException {
+		int t;
+		StringBuilder sb;
+
+		positions = new int[MAX_K];
+		map = new boolean[COL * COL];
+		br = new BufferedReader(new InputStreamReader(System.in));
+		t = Integer.parseInt(br.readLine());
+		sb = new StringBuilder();
+		while (t-- > 0) {
+			sb.append(solution()).append(LINE_BREAK);
+		}
+		System.out.print(sb.toString());
+	}
+}

--- a/problems/week04/정현우/BOJ1406_에디터.java
+++ b/problems/week04/정현우/BOJ1406_에디터.java
@@ -1,0 +1,97 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 1406 에디터
+ * - 256 ms
+ * - Linked List
+ * - 원형 양방향 Linked List 구성
+ * - NIL 노드에서 출발
+ * - L : NIL이 아니면 left로 커서 이동
+ * - D : right가 NIL이 아니면 right로 커서 이동
+ * - B : NIL이 아니면
+ * -   현재 노드의 left와 right 연결
+ * -   left로 커서 이동
+ * - P $ : $ 노드 생성
+ * -   $ 노드와 right 노드 연결
+ * -   현재 노드와 $ 노드 연결
+ * -   새로운 노드로 커서 이동
+ * - NIL의 right 부터 NIL 전까지
+ * - right 타고 이동하면서 출력
+ * */
+public class BOJ1406_에디터 {
+	private static final int NIL = 0;
+	private static final int MAX_LEN = 600_001;
+	private static final int LINE_BREAK = '\n';
+	private static final int L = 'L';
+	private static final int D = 'D';
+	private static final int B = 'B';
+	private static final int P = 'P';
+
+	public static void main(String[] args) throws IOException {
+		int m;
+		int idx;
+		int pos;
+		int size;
+		int[] left;
+		int[] right;
+		char[] str;
+		char[] ans;
+		BufferedReader br;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		str = new char[MAX_LEN];
+		left = new int[MAX_LEN];
+		right = new int[MAX_LEN];
+		pos = NIL;
+		while ((str[++pos] = (char) br.read()) != LINE_BREAK);
+		size = --pos;
+		for (idx = NIL; idx < pos; idx++) {
+			left[idx + 1] = idx;
+			right[idx] = idx + 1;
+		}
+		left[NIL] = pos;
+		right[pos] = NIL;
+		m = Integer.parseInt(br.readLine());
+		while (m-- > 0) {
+			switch (br.read()) {
+				case L:
+					if (pos != NIL) { // NIL이 아니면
+						pos = left[pos]; // left로 커서 이동
+					}
+					break;
+				case D:
+					if ((pos = right[pos]) == NIL) { // right가 NIL이 아니면
+						pos = left[NIL]; // right로 커서 이동
+					}
+					break;
+				case B:
+					if (pos != NIL) {
+						left[right[pos]] = left[pos]; // 현재 노드의 left와 right 연결
+						right[left[pos]] = right[pos];
+						pos = left[pos]; // left로 커서 이동
+						size--;
+					}
+					break;
+				case P:
+					br.read();
+					str[++idx] = (char) br.read(); // $ 노드 생성
+					left[right[pos]] = idx; // $ 노드와 right 노드 연결
+					right[idx] = right[pos];
+					left[idx] = pos; // 현재 노드와 $ 노드 연결
+					right[pos] = idx;
+					pos = idx; // 새로운 노드로 커서 이동
+					size++;
+					break;
+			}
+			br.read();
+		}
+		idx = 0;
+		ans = new char[size];
+		for (pos = right[NIL]; pos != NIL; pos = right[pos]) {
+			ans[idx++] = str[pos]; // NIL의 right 부터 NIL 전까지 right 타고 이동하면서 출력
+		}
+		System.out.print(ans);
+	}
+}

--- a/problems/week04/정현우/BOJ16234_인구이동.java
+++ b/problems/week04/정현우/BOJ16234_인구이동.java
@@ -1,0 +1,136 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 16234 인구 이동
+ * - 220 ms
+ * - DFS
+ * - map 1 차원 변환
+ * - 방문 하지 않은 노드에서 4방 탐색 DFS 출발
+ * - 국경 열어야 하는 곳 순서대로 배열에 저장
+ * - 한 번의 DFS에서 방문한 지역 수 큐에 저장
+ * - 방문한 지역이 하나면 저장하지 않음
+ * - 큐에서 숫자를 poll
+ * - 해당 숫자만큼 배열에서 좌표 꺼내기
+ * - 모인 좌표들 인구 이동 수행
+ */
+public class BOJ16234_인구이동 {
+	private static int n;
+	private static int l;
+	private static int r;
+	private static int col;
+	private static int thr;
+	private static int idx;
+	private static int cnt;
+	private static int[] d;
+	private static int[] map;
+	private static int[] positions;
+	private static boolean[] visited;
+	private static ArrayDeque<Integer> q;
+
+	private static final void dfs(int pos) {
+		int i;
+		int npos;
+		int diff;
+
+		positions[idx++] = pos; // 국경 열어야 하는 곳 순서대로 배열에 저장
+		visited[pos] = true; // 방문 처리
+		cnt++; // 한 번의 DFS에서 방문한 지역 수 카운트
+		for (i = 0; i < 4; i++) { // 4방 탐색
+			npos = pos + d[i];
+			if (visited[npos]) {
+				continue;
+			}
+			diff = Math.abs(map[pos] - map[npos]);
+			if (l <= diff && diff <= r) { // 열어야 하는 국경
+				dfs(npos);
+			}
+		}
+	}
+
+	private static final boolean open() {
+		int i;
+		int j;
+
+		idx = 0;
+		for (i = col; i < thr; i += col) {
+			for (j = 1; j <= n; j++) {
+				if (!visited[i + j]) { // 방문 하지 않은 노드에서
+					cnt = 0; // 한 번의 DFS에서 방문한 지역 수
+					dfs(i + j); // DFS 출발
+					if (cnt == 1) { // 방문한 지역이 하나면 저장하지 않음
+						visited[i + j] = false; // 방문 처리 복구
+						idx--; // 배열 인덱스 복구
+					} else {
+						q.addLast(cnt); // 한 번의 DFS에서 방문한 지역 수 큐에 저장
+					}
+				}
+			}
+		}
+		return !q.isEmpty(); // 큐가 비어있으면 멈춤
+	}
+
+	private static final void move() {
+		int i;
+		int sum;
+		int start;
+		int end;
+
+		end = 0;
+		while (!q.isEmpty()) {
+			start = end;
+			end = start + q.pollFirst(); // 큐에서 숫자 꺼내기
+			sum = 0;
+			for (i = start; i < end; i++) { // 큐에서 꺼낸 숫자만큼 배열에서 좌표 꺼내기
+				sum += map[positions[i]]; // 인구 합
+				visited[positions[i]] = false; // 방문 처리 초기화
+			}
+			sum /= end - start; // 한 지역에 들어가야 할 인구 수
+			for (i = start; i < end; i++) { // 해당 좌표들에 대해
+				map[positions[i]] = sum; // 인구 설정
+			}
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		int i;
+		int j;
+		int size;
+		int time;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		st = new StringTokenizer(br.readLine(), " ", false);
+		n = Integer.parseInt(st.nextToken());
+		l = Integer.parseInt(st.nextToken());
+		r = Integer.parseInt(st.nextToken());
+		col = n + 2;
+		thr = (n + 1) * col;
+		size = col * col;
+		map = new int[size];
+		visited = new boolean[size];
+		for (i = 1; i <= n; i++) {
+			visited[i] = true; // 위쪽 벽
+		}
+		for (i = col; i < thr; i += col) {
+			visited[i] = true; // 왼쪽 벽
+			st = new StringTokenizer(br.readLine(), " ", false);
+			for (j = 1; j <= n; j++) {
+				map[i + j] = Integer.parseInt(st.nextToken()); // map 1 차원 변환
+			}
+			visited[i + j] = true; // 오른쪽 벽
+		}
+		System.arraycopy(visited, 1, visited, thr + 1, n); // 아래쪽 벽
+		d = new int[] {-col, 1, col, -1}; // 4방 탐색
+		positions = new int[n * n];
+		q = new ArrayDeque<>();
+		for (time = 0; open(); time++) { // 국경 열기 : 큐가 비어있으면 멈춤
+			move(); // 인구 이동
+		}
+		System.out.print(time);
+	}
+}

--- a/problems/week04/정현우/BOJ21940_가운데에서만나기.java
+++ b/problems/week04/정현우/BOJ21940_가운데에서만나기.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 21940 가운데에서 만나기
+ * - 260 ms
+ * - 플로이드-워셜
+ * - 모든 노드쌍 사이의 최단 거리 구하기
+ * - C 도시들과의 최단 거리의 최대값이 최소인 노드들
+ * */
+public class BOJ21940_가운데에서만나기 {
+	private static final int INF = Integer.MAX_VALUE >> 1;
+	private static final char SPACE = ' ';
+
+	public static void main(String[] args) throws IOException {
+		int n;
+		int m;
+		int u;
+		int v;
+		int w;
+		int k;
+		int i;
+		int max;
+		int min;
+		int size;
+		int[] cities;
+		int[][] map;
+		ArrayList<Integer> ans;
+		StringBuilder sb;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		st = new StringTokenizer(br.readLine(), " ", false);
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		map = new int[n + 1][n + 1];
+		for (v = 1; v <= n; v++) {
+			map[1][v] = INF;
+		}
+		for (v = 2; v <= n; v++) {
+			System.arraycopy(map[1], 1, map[v], 1, n);
+			map[v][v] = 0;
+		}
+		map[1][1] = 0;
+		while (m-- > 0) {
+			st = new StringTokenizer(br.readLine(), " ", false);
+			map[Integer.parseInt(st.nextToken())][Integer.parseInt(st.nextToken())] = Integer.parseInt(st.nextToken());
+		}
+		for (w = 1; w <= n; w++) { // 플로이드-워셜 : 모든 노드쌍 사이의 최단 거리 구하기
+			for (u = 1; u <= n; u++) {
+				for (v = 1; v <= n; v++) {
+					map[u][v] = Math.min(map[u][v], map[u][w] + map[w][v]);
+				}
+			}
+		}
+		k = Integer.parseInt(br.readLine());
+		cities = new int[k];
+		st = new StringTokenizer(br.readLine(), " ", false);
+		for (i = 0; i < k; i++) {
+			cities[i] = Integer.parseInt(st.nextToken());
+		}
+		ans = new ArrayList<>();
+		min = INF;
+		for (w = 1; w <= n; w++) {
+			max = 0;
+			for (i = 0; i < k; i++) { // C 도시들과의 최단 거리의 최대값
+				max = Math.max(max, map[cities[i]][w] + map[w][cities[i]]);
+			}
+			if (max < min) { // 최대값이 최소인 노드들
+				ans.clear();
+				ans.add(w);
+				min = max;
+			} else if (max == min) {
+				ans.add(w);
+			}
+		}
+		sb = new StringBuilder();
+		size = ans.size();
+		for (i = 0; i < size; i++) {
+			sb.append(ans.get(i)).append(SPACE);
+		}
+		System.out.print(sb.toString());
+	}
+}

--- a/problems/week04/정현우/BOJ32354_덱조작과쿼리.java
+++ b/problems/week04/정현우/BOJ32354_덱조작과쿼리.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 32354 덱 조작과 쿼리
+ * - 508 ms
+ * - Linked List
+ * - prev를 가르키는 Linked List로 구성
+ * - 시간별 마지막 노드 저장
+ * - push x : 마지막 노드에 x를 더한 값을 가진 노드 연결
+ * - pop : prev로 이동
+ * - restore i : 시간 i의 노드 불러오기
+ * - print : 마지막 노드에 저장된 값 출력
+ * */
+public class BOJ32354_덱조작과쿼리 {
+	private static final int PUSH = 4;
+	private static final int POP = 3;
+	private static final int RESTORE = 7;
+	private static final int PRINT = 5;
+	private static final char LINE_BREAK = '\n';
+
+	public static void main(String[] args) throws IOException {
+		int n;
+		int i;
+		int[] idx;
+		int[] prev;
+		long[] sum;
+		StringBuilder sb;
+		BufferedReader br;
+		StringTokenizer st;
+
+		br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		idx = new int[n + 1]; // 시간별 마지막 노드의 인덱스
+		prev = new int[n + 1]; // 노드가 가르키는 prev
+		sum = new long[n + 1]; // 노드에 저장된 값
+		sb = new StringBuilder();
+		for (i = 1; i <= n; i++) {
+			st = new StringTokenizer(br.readLine(), " ", false);
+			switch (st.nextToken().length()) {
+				case PUSH: // 마지막 노드에 x를 더한 값을 가진 노드 연결
+					sum[idx[i] = i] = sum[prev[i] = idx[i - 1]] + Long.parseLong(st.nextToken());
+					break;
+				case POP: // prev로 이동
+					idx[i] = prev[idx[i - 1]];
+					break;
+				case RESTORE: // 시간 i의 노드 불러오기
+					idx[i] = idx[Integer.parseInt(st.nextToken())];
+					break;
+				case PRINT: // 마지막 노드에 저장된 값 출력
+					sb.append(sum[idx[i] = idx[i - 1]]).append(LINE_BREAK);
+					break;
+			}
+		}
+		System.out.print(sb.toString());
+	}
+}


### PR DESCRIPTION
## [BOJ 32354 덱 조작과 쿼리](https://github.com/Algo-Study-2409/algo-study-2409/commit/c4a88a4ad85846943290dc81ce0f4a3cfe49c888) 
- 508 ms
- Linked List
### 풀이
prev를 가르키는 Linked List로 구성
시간별 마지막 노드 저장
push x : 마지막 노드에 x를 더한 값을 가진 노드 연결
pop : prev로 이동
restore i : 시간 i의 노드 불러오기
print : 마지막 노드에 저장된 값 출력

## [BOJ 1406 에디터](https://github.com/Algo-Study-2409/algo-study-2409/commit/af166bd87e7771eca6f09c0db859fd640b377d08) 
- 256 ms
- Linked List
### 풀이
원형 양방향 Linked List 구성
NIL 노드에서 출발
L : NIL이 아니면 left로 커서 이동
D : right가 NIL이 아니면 right로 커서 이동
B : NIL이 아니면
&nbsp;&nbsp;현재 노드의 left와 right 연결
&nbsp;&nbsp;left로 커서 이동
P $ : $ 노드 생성
&nbsp;&nbsp;$ 노드와 right 노드 연결
&nbsp;&nbsp;현재 노드와 $ 노드 연결
&nbsp;&nbsp;새로운 노드로 커서 이동
NIL의 right 부터 NIL 전까지
right 타고 이동하면서 출력

## [BOJ 21940 가운데에서 만나기](https://github.com/Algo-Study-2409/algo-study-2409/commit/4d5e375cc936a141d6e5a4756ab8858454bc87c2) 
- 260 ms
- 플로이드-워셜
### 풀이
모든 노드쌍 사이의 최단 거리 구하기
C 도시들과의 최단 거리의 최대값이 최소인 노드들

## [BOJ 1012 유기농 배추](https://github.com/Algo-Study-2409/algo-study-2409/commit/f7d31f8d80bdf9364aab6b17ab5d7902bd2ad865) 
- 80 ms
- DFS
### 풀이
map 1 차원 변환
배추 위치 map에 true로 표시
true인 지점들에서 출발
4방 탐색 DFS 타면서 false로 표시
DFS 출발 할 때마다 카운트

## [BOJ 16234 인구 이동](https://github.com/Algo-Study-2409/algo-study-2409/commit/5cda929e3c5ca44e29bf3f74ccd46e6abe2c99d8) 
- 220 ms
- DFS
### 풀이
map 1 차원 변환
방문 하지 않은 노드에서 4방 탐색 DFS 출발
국경 열어야 하는 곳 순서대로 배열에 저장
한 번의 DFS에서 방문한 지역 수 큐에 저장
방문한 지역이 하나면 저장하지 않음
큐에서 숫자를 poll
해당 숫자만큼 배열에서 좌표 꺼내기
모인 좌표들 인구 이동 수행