### PR TITLE
[정현우] 6주차 문제풀이

### DIFF
--- a/problems/week06/정현우/BOJ1245_농장관리.java
+++ b/problems/week06/정현우/BOJ1245_농장관리.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1245 농장 관리
+ * - 84 ms
+ * - DFS
+ * - map 1 차원 변환
+ * - 8방 탐색
+ * - 현재 높이보다 높은 칸이 있으면
+ * -   isPeak 를 false 로 표시
+ * - 현재 높이와 같은 칸
+ * -   해당 칸으로 DFS 탐색
+ * - isPeak 이 true 로 남아있으면
+ * -   봉우리 개수 추가
+ * */
+public class BOJ1245_농장관리 {
+    private static final int WALL = -1;
+
+    private static int[] d;
+    private static int[] map;
+    private static boolean isPeak;
+    private static boolean[] visited;
+
+    private static final void dfs(int pos) {
+        int i;
+        int npos;
+
+        visited[pos] = true; // 방문 처리
+        for (i = 0; i < 8; i++) { // 8방 탐색
+            npos = pos + d[i];
+            if (isPeak && map[npos] > map[pos]) { // 현재 높이보다 높은 칸이 있으면
+                isPeak = false; // isPeak 를 false 로 표시
+            } else if (map[npos] == map[pos] && !visited[npos]) { // 현재 높이와 같은 칸
+                dfs(npos); // 해당 칸으로 DFS 탐색
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int m;
+        int i;
+        int j;
+        int col;
+        int thr;
+        int cnt;
+        int size;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        col = m + 2;
+        thr = (n + 1) * col;
+        size = thr + col;
+        map = new int[size]; // map 1 차원 변환
+        for (i = 0; i < col; i++) {
+            map[i] = WALL; // 위쪽 벽
+        }
+        for (i = col; i < thr; i += col) {
+            map[i] = WALL; // 왼쪽 벽
+            st = new StringTokenizer(br.readLine(), " ", false);
+            for (j = 1; j <= m; j++) { // 농장 입력
+                map[i + j] = Integer.parseInt(st.nextToken());
+            }
+            map[i + m + 1] = WALL; // 오른쪽 벽
+        }
+        System.arraycopy(map, 0, map, thr, col); // 아래쪽 벽
+        visited = new boolean[size]; // 방문 여부
+        d = new int[] {-col, -col + 1, 1, col + 1, col, col - 1, -1, -col - 1}; // 8방 탐색
+        cnt = 0;
+        for (i = col; i < thr; i += col) {
+            for (j = 1; j <= m; j++) {
+                if (!visited[i + j]) { // 방문하지 않은 노드
+                    isPeak = true; // isPeak 초기화
+                    dfs(i + j); // DFS
+                    if (isPeak) { // isPeak 이 true 로 남아있으면
+                        cnt++; // 봉우리 개수 추가
+                    }
+                }
+            }
+        }
+        System.out.print(cnt);
+    }
+}

--- a/problems/week06/정현우/BOJ1405_미친로봇.java
+++ b/problems/week06/정현우/BOJ1405_미친로봇.java
@@ -1,0 +1,63 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1405 미친 로봇
+ * - 108 ms
+ * - 브루트포스
+ * - (2N + 1) * (2N + 1) map
+ * - map 1 차원 변환
+ * - (N, N) 출발
+ * - 모든 경로 4방 탐색
+ * - 방문한 지점은 재방문 하지 않음
+ * - 현재 경로가 선택될 확률 계산
+ * - N 길이 경로의 확률 합 출력
+ * */
+public class BOJ1405_미친로봇 {
+    private static final double TOTAL = 100.0;
+
+    private static int n;
+    private static int col;
+    private static double ans;
+    private static double east;
+    private static double west;
+    private static double south;
+    private static double north;
+    private static boolean[] visited;
+
+    private static void dfs(int pos, double probability, int depth) {
+        if (visited[pos]) { // 이미 방문한 지점
+            return;
+        }
+        if (depth == n) { // N 길이 경로
+            ans += probability; // 확률 합 계산
+            return;
+        }
+        depth++; // 다음 depth
+        visited[pos] = true; // 방문 처리
+        dfs(pos + 1, probability * east, depth); // 4방 탐색
+        dfs(pos - 1, probability * west, depth); // 현재 경로 확률 * 방향별 확률
+        dfs(pos + col, probability * south, depth);
+        dfs(pos - col, probability * north, depth);
+        visited[pos] = false; // 방문 여부 원상 복구
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        east = Integer.parseInt(st.nextToken()) / TOTAL; // 동
+        west = Integer.parseInt(st.nextToken()) / TOTAL; // 서
+        south = Integer.parseInt(st.nextToken()) / TOTAL; // 남
+        north = Integer.parseInt(st.nextToken()) / TOTAL; // 북
+        col = (n << 1) + 1; // 2N + 1
+        visited = new boolean[col * col]; // map 1 차원 변환
+        dfs(n * col + n, 1.0, 0); // (N, N) 출발
+        System.out.print(ans); // 확률 합 출력
+    }
+}

--- a/problems/week06/정현우/BOJ2606_바이러스.java
+++ b/problems/week06/정현우/BOJ2606_바이러스.java
@@ -1,0 +1,53 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 2606 바이러스
+ * - 64 ms
+ * - Union-Find
+ * - 직접 연결된 컴퓨터들 Union
+ * - 집합 크기 roots 에 음수로 저장
+ * - 1 번 컴퓨터가 속한 집합의 크기 - 1
+ * */
+public class BOJ2606_바이러스 {
+    private static int[] roots;
+
+    private static final int find(int v) {
+        if (roots[v] <= 0) { // Find
+            return v;
+        }
+        return roots[v] = find(roots[v]); // Path Compression
+    }
+
+    private static final void union(int u, int v) {
+        u = find(u);
+        v = find(v);
+        if (u == v) {
+            return;
+        }
+        roots[u] += roots[v]; // 집합 크기 합치기
+        roots[v] = u; // Union
+    }
+
+    public static void main(String[] args) throws IOException {
+        int networks;
+        int computers;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        computers = Integer.parseInt(br.readLine()) + 1;
+        networks = Integer.parseInt(br.readLine());
+        roots = new int[computers]; // 양수 : 부모, 음수 : 집합 크기
+        while (--computers > 0) {
+            roots[computers] = -1; // 초기 집합 크기 설정
+        }
+        while (networks-- > 0) { // 직접 연결된 컴퓨터들 Union
+            st = new StringTokenizer(br.readLine(), " ", false);
+            union(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));
+        }
+        System.out.print(-roots[find(1)] - 1); // 1 번 컴퓨터가 속한 집합의 크기 - 1
+    }
+}

--- a/problems/week06/정현우/BOJ27924_윤이는엄청난것을훔쳐갔습니다.java
+++ b/problems/week06/정현우/BOJ27924_윤이는엄청난것을훔쳐갔습니다.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 27924 윤이는 엄청난 것을 훔쳐갔습니다
+ * - 428 ms
+ * - BFS
+ * - b, c, a 에서 각각 BFS로 출발
+ * - a 에서 출발한 탐색이
+ * -   리프 노드에 도달하면 YES 출력
+ * - a 에서 출발한 탐색인지 확인
+ * -   노드 번호를 IS_A flag 와 OR 연산하여 표시
+ * - IS_A = 가장 왼쪽 비트만 1 인 int 로 설정
+ * */
+public class BOJ27924_윤이는엄청난것을훔쳐갔습니다 {
+    private static final int IS_A = Integer.MIN_VALUE; // 가장 왼쪽 비트만 1 인 int
+    private static final char[] YES = {'Y', 'E', 'S'};
+    private static final char[] NO = {'N', 'O'};
+
+    private static final class Edge {
+        int to;
+        Edge next;
+
+        Edge(int to, Edge next) {
+            this.to = to;
+            this.next = next;
+        }
+    }
+
+    private static int n;
+    private static Edge[] adj;
+
+    private static final boolean bfs(int a, int b, int c) {
+        int curr;
+        int flag;
+        boolean[] visited;
+        Edge edge;
+        ArrayDeque<Integer> q;
+
+        visited = new boolean[n + 1];
+        q = new ArrayDeque<>(n);
+        visited[a] = visited[b] = visited[c] = true;
+        q.addLast(b); // b, c 를 a 보다 먼저 출발 시킴
+        q.addLast(c);
+        q.addLast(a | IS_A); // a 에서 출발 표시
+        while (!q.isEmpty()) {
+            curr = q.pollFirst();
+            flag = curr & IS_A; // flag : a 에서 출발한 탐색인지 여부
+            curr ^= flag; // flag 제거하여 노드 번호만 추출
+            if (adj[curr].next == null && flag == IS_A) {
+                return true; // a 에서 출발한 탐색이 리프 노드에 도달
+            }
+            for (edge = adj[curr]; edge != null; edge = edge.next) {
+                if (!visited[edge.to]) {
+                    visited[edge.to] = true; // 다음 노드
+                    q.addLast(flag | edge.to); // flag 와 OR 연산하여 표시
+                }
+            }
+        }
+        return false;
+    }
+
+    public static void main(String[] args) throws IOException {
+        int u;
+        int v;
+        int i;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        adj = new Edge[n + 1];
+        for (i = 1; i < n; i++) {
+            st = new StringTokenizer(br.readLine(), " ", false);
+            u = Integer.parseInt(st.nextToken());
+            v = Integer.parseInt(st.nextToken());
+            adj[u] = new Edge(v, adj[u]); // 양방향 간선 입력
+            adj[v] = new Edge(u, adj[v]);
+        }
+        st = new StringTokenizer(br.readLine(), " ", false);
+        if (bfs(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()))) {
+            System.out.print(YES); // BFS 가 true 반환
+        } else {
+            System.out.print(NO); // BFS 가 false 반환
+        }
+    }
+}

--- a/problems/week06/정현우/PGS43164_여행경로.java
+++ b/problems/week06/정현우/PGS43164_여행경로.java
@@ -1,0 +1,98 @@
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * 정현우 : PGS 43164 여행경로
+ * - 0.25 ms
+ * - DFS
+ * - HashMap 에 공항 이름별 공항 객체 저장
+ * - 이름의 char 3 개로 정렬용 code 생성
+ * - 공항별 갈 수 있는 목적지 정렬
+ * - 인천에서 출발, 간선 visited 처리 하면서 DFS
+ * - 결과 배열 모두 채워지면 종료
+ * */
+public class PGS43164_여행경로 {
+    private static final Airport START = new Airport("ICN"); // 인천 공항
+
+    private static final class Airport implements Comparable<Airport> {
+        private static int len; // 결과 배열의 길이
+        private static String[] ret; // 결과 배열
+
+        int code;
+        int degree;
+        boolean[] visited;
+        String name;
+        ArrayList<Airport> to;
+
+        Airport(String name) {
+            this.name = name; // 공항 이름
+            this.code = getCode(name); // 정렬용 코드
+            to = new ArrayList<>(); // 목적지 목록
+        }
+
+        @Override
+        public int compareTo(Airport o) {
+            return code - o.code;
+        }
+
+        private static final int getCode(String name) { // 정렬용 code 생성
+            return name.charAt(0) << 16 | name.charAt(1) << 8 | name.charAt(2);
+        }
+
+        private final boolean dfs(int depth) { // DFS
+            int i;
+
+            ret[depth++] = name; // 결과 배열 채우기
+            if (depth == len) { // 결과 배열 모두 채워짐
+                return true; // 종료
+            }
+            for (i = 0; i < degree; i++) { // 간선 탐색
+                if (visited[i]) { // 방문한 간선
+                    continue;
+                }
+                visited[i] = true; // 간선 방문 처리
+                if (to.get(i).dfs(depth)) { // 다음 공항으로 이동
+                    return true; // 해당 간선을 통해 결과 배열이 모두 채워짐
+                }
+                visited[i] = false; // 방문 여부 원상 복구
+            }
+            return false; // 현재 상태로 결과 배열 채우기 실패
+        }
+
+        final void init() { // 공항 초기화
+            degree = to.size(); // 진출 차수
+            visited = new boolean[degree]; // 간선 방문 여부
+            Collections.sort(to); // 목적지 정렬
+        }
+
+        final String[] toStringArray(int len) { // 결과 배열 생성
+            Airport.len = len; // 결과 배열의 길이
+            ret = new String[len]; // 결과 배열
+            dfs(0); // DFS
+            return ret;
+        }
+    }
+
+    public String[] solution(String[][] tickets) {
+        Airport u;
+        Airport v;
+        HashMap<String, Airport> airports;
+
+        airports = new HashMap<>(); // 공항 이름별 공항 객체 저장
+        airports.put(START.name, START); // 인천 공항
+        for (String[] ticket : tickets) { // 항공권
+            if ((u = airports.get(ticket[0])) == null) { // HashMap 에 출발 공항이 없으면
+                airports.put(ticket[0], u = new Airport(ticket[0])); // 공항 생성
+            }
+            if ((v = airports.get(ticket[1])) == null) { // HashMap 에 도착 공항이 없으면
+                airports.put(ticket[1], v = new Airport(ticket[1])); // 공항 생성
+            }
+            u.to.add(v); // 출발 공항의 목적지 목록에 도착 공항 추가
+        }
+        for (Airport airport : airports.values()) { // 모든 공항
+            airport.init(); // 내부 초기화
+        }
+        return START.toStringArray(tickets.length + 1); // 인천에서 출발, 결과 배열 생성
+    }
+}


### PR DESCRIPTION
## [BOJ 1405 미친 로봇](https://github.com/Algo-Study-2409/algo-study-2409/commit/aecb9376079f8acb65358a7ad9c5f13c3d9b9cf7) 

- 108 ms
- 브루트포스
### 풀이
(2N + 1) * (2N + 1) map
map 1 차원 변환
(N, N) 출발
모든 경로 4방 탐색
방문한 지점은 재방문 하지 않음
현재 경로가 선택될 확률 계산
N 길이 경로의 확률 합 출력

## [BOJ 1245 농장 관리](https://github.com/Algo-Study-2409/algo-study-2409/commit/ccde1c9e3d6702116a746aa4b428e93bccc69360) 

- 84 ms
- DFS
### 풀이
map 1 차원 변환
8방 탐색
현재 높이보다 높은 칸이 있으면
&nbsp;&nbsp;isPeak 를 false 로 표시
현재 높이와 같은 칸
&nbsp;&nbsp;해당 칸으로 DFS 탐색
isPeak 이 true 로 남아있으면
&nbsp;&nbsp;봉우리 개수 추가

## [BOJ 27924 윤이는 엄청난 것을 훔쳐갔습니다](https://github.com/Algo-Study-2409/algo-study-2409/commit/c20eb5cefd27c228c48b1a991e481c365f58c7b3) 

- 428 ms
- BFS
### 풀이
b, c, a 에서 각각 BFS로 출발
a 에서 출발한 탐색이
&nbsp;&nbsp;리프 노드에 도달하면 YES 출력
a 에서 출발한 탐색인지 확인
&nbsp;&nbsp;노드 번호를 IS_A flag 와 OR 연산하여 표시
IS_A = 가장 왼쪽 비트만 1 인 int 로 설정

## [PGS 43164 여행경로](https://github.com/Algo-Study-2409/algo-study-2409/commit/f60a7f0a61240acaa4c09e75a556bf83c14bca10) 

- 0.25 ms
- DFS
### 풀이
HashMap 에 공항 이름별 공항 객체 저장
이름의 char 3 개로 정렬용 code 생성
공항별 갈 수 있는 목적지 정렬
인천에서 출발, 간선 visited 처리 하면서 DFS
결과 배열 모두 채워지면 종료

## [BOJ 2606 바이러스](https://github.com/Algo-Study-2409/algo-study-2409/commit/bfcd238b44d064107f3941a77ebbf710926c94f5) 

- 64 ms
- Union-Find
### 풀이
직접 연결된 컴퓨터들 Union
집합 크기 roots 에 음수로 저장
1 번 컴퓨터가 속한 집합의 크기 - 1