### PR TITLE
[정현우] 8주차 문제풀이

### DIFF
--- a/problems/week08/정현우/BOJ1149_RGB거리.java
+++ b/problems/week08/정현우/BOJ1149_RGB거리.java
@@ -1,0 +1,38 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1149 RGB거리
+ * - 72 ms
+ * - DP
+ * - 마지막을 빨강으로 칠하는 비용
+ * -   = min(직전에 초록을 칠했을 때의 비용,
+ * -     직전에 파랑을 칠했을 때의 비용)
+ * - 초록, 파랑도 동일한 방법으로 계산
+ * - 셋 중 가장 적은 비용 출력
+ * */
+public class BOJ1149_RGB거리 {
+    public static void main(String[] args) throws IOException {
+        int n;
+        int red;
+        int green;
+        int blue;
+        int prevRed;
+        int prevGreen;
+        int prevBlue;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        for (prevRed = 0, prevGreen = 0, prevBlue = 0; n-- > 0; prevRed = red, prevGreen = green, prevBlue = blue) {
+            st = new StringTokenizer(br.readLine(), " ", false);
+            red = Math.min(prevGreen, prevBlue) + Integer.parseInt(st.nextToken()); // min(직전에 초록 or 파랑을 칠했을 때의 비용)
+            green = Math.min(prevBlue, prevRed) + Integer.parseInt(st.nextToken()); // min(직전에 파랑 or 빨강을 칠했을 때의 비용)
+            blue = Math.min(prevRed, prevGreen) + Integer.parseInt(st.nextToken()); // min(직전에 빨강 or 초록을 칠했을 때의 비용)
+        }
+        System.out.print(Math.min(Math.min(prevRed, prevGreen), prevBlue)); // 셋 중 가장 적은 비용 출력
+    }
+}

--- a/problems/week08/정현우/BOJ1660_캡틴이다솜.java
+++ b/problems/week08/정현우/BOJ1660_캡틴이다솜.java
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 1660 캡틴 이다솜
+ * - 116 ms
+ * - DP
+ * - 길이별 대포알 개수 배열 생성
+ * - 길이 x 의 사면체 대포알 개수
+ * -   = x * (x + 1) * (x + 2) / 6
+ * - 길이 x + 1 의 사면체 대포알 개수
+ * -   = (x + 1) * (x + 2) * (x + 3) / 6
+ * -   = (길이 x 의 사면체 대포알 개수) * (x + 3) / x
+ * - dp[i] : i 개의 대포알로 만들 수 있는 사면체의 최소 개수
+ * - dp[i] = min(dp[i - (사면체 대포알 개수)] + 1)
+ * */
+class BOJ1660_캡틴이다솜 {
+    private static int n;
+    private static int[] arr;
+
+    private static void initArr(int depth, int val) {
+        if (val > n) { // 최대 대포알 초과
+            arr = new int[depth + 1]; // 배열 생성
+        } else { // 길이 x + 1 의 사면체 대포알 개수
+            initArr(depth + 1, val * (depth + 3) / depth);
+        }
+        arr[depth] = val; // 길이 x 의 사면체 대포알 개수
+    }
+
+    public static void main(String[] args) throws IOException {
+        int i;
+        int j;
+        int start;
+        int[] dp;
+        BufferedReader br;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        initArr(1, 1); // 길이별 대포알 개수 배열 생성
+        dp = new int[n + 1];
+        start = 0;
+        for (i = 1; i <= n; i++) {
+            if (i == arr[start + 1]) { // 다음 사면체를 만들수 있는 개수 도달
+                start++; // i 개 이하를 사용하는 가장 큰 사면체
+            }
+            dp[i] = i; // 크기 1 의 사면체만으로 구성
+            for (j = start; j > 0; j--) { // i 개 이하를 사용하는 사면체들
+                dp[i] = Math.min(dp[i], dp[i - arr[j]] + 1);
+            } // min(dp[i - (사면체 대포알 개수)] + 1)
+        }
+        System.out.print(dp[n]); // N 개의 대포알로 만들 수 있는 사면체의 최소 개수
+    }
+}

--- a/problems/week08/정현우/BOJ2876_그래픽스퀴즈.java
+++ b/problems/week08/정현우/BOJ2876_그래픽스퀴즈.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 2876 그래픽스 퀴즈
+ * - 120 ms
+ * - DP
+ * - len : 현재 학생으로 끝나는 연속된 그레이드 길이
+ * - 이전 줄에 동일한 그레이드의 학생이 있으면
+ * - len = (이전 해당 학생으로 끝나는 연속된 그레이드 길이) + 1
+ * - 이전 줄에 동일한 그레이드의 학생이 없으면
+ * - len = 1
+ * - 최대 길이와 해당 길이에서 최소 그레이드 출력
+ * */
+public class BOJ2876_그래픽스퀴즈 {
+    private static final char SPACE = ' ';
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int max;
+        int lenLeft;
+        int lenRight;
+        int prevLenLeft;
+        int prevLenRight;
+        char grade;
+        char left;
+        char right;
+        char prevLeft;
+        char prevRight;
+        BufferedReader br;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        prevLeft = prevRight = grade = SPACE; // 초기 그레이드 없음
+        prevLenLeft = prevLenRight = max = 0; // 초기 길이 없음
+        while (n-- > 0) {
+            left = (char) br.read(); // 왼쪽 학생 그레이드
+            br.read();
+            right = (char) br.read(); // 오른쪽 학생 그레이드
+            br.read();
+            if (left == prevLeft) { // 현재 왼쪽 학생이 이전 왼쪽 학생의 그레이드와 같으면
+                lenLeft = prevLenLeft + 1; // (이전 왼쪽 학생으로 끝나는 연속된 그레이드 길이) + 1
+            } else if (left == prevRight) { // 이전 오른쪽 학생의 그레이드와 같으면
+                lenLeft = prevLenRight + 1; // (이전 오른쪽 학생으로 끝나는 연속된 그레이드 길이) + 1
+            } else { // 이전 줄에 동일한 그레이드의 학생이 없으면
+                lenLeft = 1;
+            }
+            if (right == prevRight) { // 현재 오른쪽 학생이 이전 왼쪽 학생의 그레이드와 같으면
+                lenRight = prevLenRight + 1; // (이전 왼쪽 학생으로 끝나는 연속된 그레이드 길이) + 1
+            } else if (right == prevLeft) { // 이전 오른쪽 학생의 그레이드와 같으면
+                lenRight = prevLenLeft + 1; // (이전 오른쪽 학생으로 끝나는 연속된 그레이드 길이) + 1
+            } else { // 이전 줄에 동일한 그레이드의 학생이 없으면
+                lenRight = 1;
+            }
+            if (lenLeft > max) { // 왼쪽 길이가 최대 길이 갱신
+                grade = left; // 최소 그레이드 업데이트
+                max = lenLeft; // 최대 길이 업데이트
+            } else if (lenLeft == max) { // 최대 길이와 동일
+                if (left < grade) { // 최소 그레이드 업데이트
+                    grade = left;
+                }
+            }
+            if (lenRight > max) { // 오른쪽 길이가 최대 길이 갱신
+                grade = right; // 최소 그레이드 업데이트
+                max = lenRight; // 최대 길이 업데이트
+            } else if (lenRight == max) { // 최대 길이와 동일
+                if (right < grade) { // 최소 그레이드 업데이트
+                    grade = right;
+                }
+            }
+            prevLeft = left; // 다음 줄 수행 전 현재 정보를 이전 정보로 이동
+            prevRight = right;
+            prevLenLeft = lenLeft;
+            prevLenRight = lenRight;
+        } // 최대 길이와 해당 길이에서 최소 그레이드 출력
+        System.out.print(new StringBuilder().append(max).append(SPACE).append(grade).toString());
+    }
+}

--- a/problems/week08/정현우/SFT7369_나무수확.java
+++ b/problems/week08/정현우/SFT7369_나무수확.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : SFT 7369 나무 수확
+ * - 305 ms
+ * - DP
+ * - (i, j) 에서 수로가 끝날 때
+ * - dp[i][j] : 스프링클러 없이 최대 수확량
+ * - sprinkler[i][j] : 스프링클러 포함 최대 수확량
+ * - dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+ * - sprinkler[i][j]
+ * -   = max(sprinkler[i - 1][j], sprinkler[i][j - 1],
+ * -     dp[i][j] + ((i, j) 수확량))
+ * - (i, j) 가 (i - 1, j) 와 (i, j - 1) 만 참조하므로
+ * -   배열 1 차원으로 변환
+ * */
+public class SFT7369_나무수확 {
+    public static void main(String[] args) throws IOException {
+        int n;
+        int i;
+        int j;
+        int val;
+        int[] dp;
+        int[] sprinkler;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        dp = new int[n + 1]; // 스프링클러 없이 최대 수확량
+        sprinkler = new int[n + 1]; // 스프링클러 포함 최대 수확량
+        for (i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine(), " ", false);
+            for (j = 1; j <= n; j++) {
+                val = Integer.parseInt(st.nextToken()); // (i, j) 수확량
+                dp[j] = Math.max(dp[j], dp[j - 1]) + val; // max(dp[i - 1][j], dp[i][j - 1])
+                sprinkler[j] = Math.max(Math.max(sprinkler[j], sprinkler[j - 1]), dp[j]) + val;
+            } // max(sprinkler[i - 1][j], sprinkler[i][j - 1], dp[i][j] + ((i, j) 수확량))
+        }
+        System.out.println(sprinkler[n]);
+    }
+}

--- a/problems/week08/정현우/SFT7699_HanyangCherryPickingContest.java
+++ b/problems/week08/정현우/SFT7699_HanyangCherryPickingContest.java
@@ -1,0 +1,138 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/**
+ * 정현우 : SFT 7699 Hanyang Cherry Picking Contest
+ * - 780 ms
+ * - 게임 이론 + 그리디 + 트리 DP
+ * - 항상 DFS 순서로 정점이 선택됨
+ * -   = 정점을 선택하면 해당 정점을 루트로 하는 서브 트리가 전부 끝난 후 돌아옴
+ * - 정점의 가치 : 해당 정점을 루트로 하는 서브 트리를 모두 선택했을 때
+ * -   (내가 얻는 점수) - (상대가 얻는 점수)
+ * - 선택할 수 있는 상황 : 특정 부모 정점의 자식 정점들 중에 하나를 선택
+ * - 정점 타입
+ * -   A. 정점 선택 후 서브 트리에 대한 선택이 끝났을 때 다시 내 턴인 정점
+ * -     A1. 정점의 가치가 양수
+ * -     A2. 정점의 가치가 음수 (가치 0 은 의미 없음, 임의로 A2 에 포함)
+ * -   B. 정점 선택 후 서브 트리에 대한 선택이 끝났을 때 턴이 전환되는 정점
+ * - 최적의 선택
+ * -   1. 처음 선택권을 가진 플레이어(부모 정점 선택자의 상대편)가 A1 타입들을 모두 선택
+ * -   2. B 타입들을 가치가 높은 것부터 번갈아가며 선택
+ * -   3. 마지막에 턴을 받은 플레이어가 A2 타입들을 모두 선택
+ * -   자식 정점을 A1 - B - A2 순으로 정렬 후 B 타입을 만날 때마다 턴 전환하며 하나씩 반영
+ * - 부모 정점의 가치
+ * -   (부모 정점에 쓰인 숫자)
+ * -     - (부모 정점 선택자의 상대편이 선택하게 된 자식 정점의 가치 합)
+ * -     + (부모 정점 선택자가 선택하게 된 자식 정점의 가치 합)
+ * - 정점 1 의 가치가 양수면 세훈 승, 음수면 철민 승, 0 이면 비김
+ * */
+public class SFT7699_HanyangCherryPickingContest {
+    private static final int NIL = 0;
+    private static final char[] SEHUN = {'S', 'e', 'h', 'u', 'n'};
+    private static final char[] CHEOLMIN = {'C', 'h', 'e', 'o', 'l', 'm', 'i', 'n'};
+    private static final char[] DRAW = {'D', 'r', 'a', 'w'};
+    private static final Comparator CMP = new Comparator<Integer>() {
+        @Override
+        public int compare(Integer o1, Integer o2) { // 자식 정점 정렬 기준
+            if (o1 == exclude) { // 제외된 정점(부모 정점) 가장 뒤로 보내기
+                return 1;
+            }
+            if (o2 == exclude) { // 제외된 정점(부모 정점) 가장 뒤로 보내기
+                return -1;
+            }
+            if (!isChange[o1]) { // A 타입
+                if (score[o1] > 0L) { // A1 타입
+                    return -1; // 가장 앞으로
+                } else { // A2 타입
+                    return 1; // 가장 뒤로
+                }
+            }
+            if (!isChange[o2]) { // A 타입
+                if (score[o2] > 0L) { // A1 타입
+                    return 1; // 가장 앞으로
+                } else { // A2 타입
+                    return -1; // 가장 뒤로
+                }
+            }
+            if (score[o1] > score[o2]) { // B 타입 : 정점의 가치 내림차순
+                return -1;
+            }
+            return 1;
+        }
+    };
+
+    private static int exclude;
+    private static long[] score;
+    private static boolean[] isChange;
+    private static ArrayList<Integer>[] adj;
+
+    private static final void dfs(int parent, int curr) {
+        int i;
+        int child;
+        int degree;
+        boolean flag;
+        ArrayList<Integer> children;
+
+        children = adj[curr]; // 자식 정점들
+        degree = children.size() - 1; // 진출 차수 (부모 제외)
+        for (int next : children) {
+            if (next == parent) {
+                continue;
+            }
+            dfs(curr, next); // 자식 정점 가치 계산
+        }
+        exclude = parent; // 부모 정점 제외
+        Collections.sort(children, CMP); // 정점 정렬
+        flag = true; // 시작은 부모 정점을 선택한 플레이어의 상대편 턴
+        for (i = 0; i < degree; i++) { // 자식 정점 순회
+            child = children.get(i); // 자식 정점
+            if (flag) { // 부모 정점을 선택한 플레이어의 상대편 턴
+                score[curr] -= score[child]; // 부모 정점의 가치 -= 자식 정점의 가치
+            } else { // 부모 정점을 선택한 플레이어의 턴
+                score[curr] += score[child]; // 부모 정점의 가치 += 자식 정점의 가치
+            }
+            flag ^= isChange[child]; // 자식 정점이 B 타입이면 턴 전환
+        }
+        isChange[curr] = flag; // 마지막 턴을 가져간 플레이어에 따라 부모 정점의 타입 결정
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int u;
+        int v;
+        int i;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        adj = new ArrayList[n + 1];
+        for (i = 1; i <= n; i++) {
+            adj[i] = new ArrayList<>();
+        }
+        for (i = 1; i < n; i++) { // 간선 입력
+            st = new StringTokenizer(br.readLine(), " ", false);
+            u = Integer.parseInt(st.nextToken());
+            v = Integer.parseInt(st.nextToken());
+            adj[u].add(v);
+            adj[v].add(u);
+        }
+        score = new long[n + 1];
+        st = new StringTokenizer(br.readLine(), " ", false);
+        for (i = 1; i <= n; i++) {
+            score[i] = Long.parseLong(st.nextToken());
+        }
+        isChange = new boolean[n + 1]; // 선택했을 때 턴이 전환되는 B 타입 정점인지
+        adj[1].add(NIL); // 정점 1 에 임의의 0 번 정점을 부모로 추가
+        dfs(NIL, 1); // 부모 0, 정점 1 에서 DFS 출발
+        if (score[1] > 0L) { // 정점 1 의 가치가 양수
+            System.out.print(SEHUN);
+        } else if (score[1] < 0L) { // 정점 1 의 가치가 음수
+            System.out.print(CHEOLMIN);
+        } else { // 정점 1 의 가치가 0
+            System.out.print(DRAW);
+        }
+    }
+}


### PR DESCRIPTION
## [SFT 7369 나무 수확](https://github.com/Algo-Study-2409/algo-study-2409/commit/05f663b409034bb6dad14eeae32e08e592eb40ae) 

- 305 ms
- DP
### 풀이
(i, j) 에서 수로가 끝날 때
dp[i][j] : 스프링클러 없이 최대 수확량
sprinkler[i][j] : 스프링클러 포함 최대 수확량
dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
sprinkler[i][j]
&nbsp;&nbsp;= max(sprinkler[i - 1][j], sprinkler[i][j - 1],
&nbsp;&nbsp;&nbsp;&nbsp;dp[i][j] + ((i, j) 수확량))
(i, j) 가 (i - 1, j) 와 (i, j - 1) 만 참조하므로
&nbsp;&nbsp;배열 1 차원으로 변환

## [BOJ 1149 RGB거리](https://github.com/Algo-Study-2409/algo-study-2409/commit/c5b3c4c265f1fcb64fa3e9cbb0e749d43f0460d2) 

- 72 ms
- DP
### 풀이
마지막을 빨강으로 칠하는 비용
&nbsp;&nbsp;= min(직전에 초록을 칠했을 때의 비용,
&nbsp;&nbsp;&nbsp;&nbsp;직전에 파랑을 칠했을 때의 비용)
초록, 파랑도 동일한 방법으로 계산
셋 중 가장 적은 비용 출력

## [BOJ 1660 캡틴 이다솜](https://github.com/Algo-Study-2409/algo-study-2409/commit/5803871afd27232d9a63586bff367963836b534c) 

- 116 ms
- DP
### 풀이
길이별 대포알 개수 배열 생성
길이 x 의 사면체 대포알 개수
&nbsp;&nbsp;= x * (x + 1) * (x + 2) / 6
길이 x + 1 의 사면체 대포알 개수
&nbsp;&nbsp;= (x + 1) * (x + 2) * (x + 3) / 6
&nbsp;&nbsp;= (길이 x 의 사면체 대포알 개수) * (x + 3) / x
dp[i] : i 개의 대포알로 만들 수 있는 사면체의 최소 개수
dp[i] = min(dp[i - (사면체 대포알 개수)] + 1)

## [BOJ 2876 그래픽스 퀴즈](https://github.com/Algo-Study-2409/algo-study-2409/commit/b61c2f8b7acb3d90c5734ed18d1b71d8f9a88cd6) 

- 120 ms
- DP
### 풀이
len : 현재 학생으로 끝나는 연속된 그레이드 길이
이전 줄에 동일한 그레이드의 학생이 있으면
len = (이전 해당 학생으로 끝나는 연속된 그레이드 길이) + 1
이전 줄에 동일한 그레이드의 학생이 없으면
len = 1
최대 길이와 해당 길이에서 최소 그레이드 출력

## [SFT 7699 Hanyang Cherry Picking Contest](https://github.com/Algo-Study-2409/algo-study-2409/commit/028c09681a86e9bf3c03dd6537404cf39979f705) 

- 780 ms
- 게임 이론 + 그리디 + 트리 DP
### 풀이
항상 DFS 순서로 정점이 선택됨
&nbsp;&nbsp;= 정점을 선택하면 해당 정점을 루트로 하는 서브 트리가 전부 끝난 후 돌아옴
정점의 가치 : 해당 정점을 루트로 하는 서브 트리를 모두 선택했을 때
&nbsp;&nbsp;(내가 얻는 점수) - (상대가 얻는 점수)
선택할 수 있는 상황 : 특정 부모 정점의 자식 정점들 중에 하나를 선택
정점 타입
&nbsp;&nbsp;A. 정점 선택 후 서브 트리에 대한 선택이 끝났을 때 다시 내 턴인 정점
&nbsp;&nbsp;&nbsp;&nbsp;A1. 정점의 가치가 양수
&nbsp;&nbsp;&nbsp;&nbsp;A2. 정점의 가치가 음수 (가치 0 은 의미 없음, 임의로 A2 에 포함)
&nbsp;&nbsp;B. 정점 선택 후 서브 트리에 대한 선택이 끝났을 때 턴이 전환되는 정점
최적의 선택
&nbsp;&nbsp;1. 처음 선택권을 가진 플레이어(부모 정점 선택자의 상대편)가 A1 타입들을 모두 선택
&nbsp;&nbsp;2. B 타입들을 가치가 높은 것부터 번갈아가며 선택
&nbsp;&nbsp;3. 마지막에 턴을 받은 플레이어가 A2 타입들을 모두 선택
&nbsp;&nbsp;자식 정점을 A1 - B - A2 순으로 정렬 후 B 타입을 만날 때마다 턴 전환하며 하나씩 반영
부모 정점의 가치
&nbsp;&nbsp;(부모 정점에 쓰인 숫자)
&nbsp;&nbsp;&nbsp;&nbsp;- (부모 정점 선택자의 상대편이 선택하게 된 자식 정점의 가치 합)
&nbsp;&nbsp;&nbsp;&nbsp;+ (부모 정점 선택자가 선택하게 된 자식 정점의 가치 합)
정점 1 의 가치가 양수면 세훈 승, 음수면 철민 승, 0 이면 비김