### PR TITLE
[김민선] 8주차 문제풀이

### DIFF
--- a/problems/week08/김민선/BOJ1149_RGB거리.cpp
+++ b/problems/week08/김민선/BOJ1149_RGB거리.cpp
@@ -1,0 +1,26 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+int N;
+int dp[1001][3]; // i번 째 집을 빨, 초, 파로 칠했을 때의 최소 비용
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    cin >> N;
+
+    int r, g, b;
+    for (int i = 1; i <= N; i++) {
+        cin >> r >> g >> b;
+
+        dp[i][0] = min(dp[i - 1][1], dp[i - 1][2]) + r;
+        dp[i][1] = min(dp[i - 1][0], dp[i - 1][2]) + g;
+        dp[i][2] = min(dp[i - 1][0], dp[i - 1][1]) + b;
+    }
+
+    cout << min({dp[N][0], dp[N][1], dp[N][2]}) << "\n";
+
+    return 0;
+}

--- a/problems/week08/김민선/BOJ1660_캡틴 이다솜.cpp
+++ b/problems/week08/김민선/BOJ1660_캡틴 이다솜.cpp
@@ -1,0 +1,51 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+/*
+    - 32ms
+    - 주어진 대포알수로 만들 수 있는 최소 사면체의 수
+    - 사면체는 정삼각형의 합으로 만들 수 있음
+    - i번째 사면체는 i-1번째 사면체 + i번째 정삼각형의 합으로 만들 수 있음
+    - dp[i] i개가 주어질 때 최소 사면체의 수
+    - dp[i] = min(dp[i], dp [i - arr[j]] + 1)
+        - i - arr[j]개가 주어질 때 최소 사면체의 수 + 1
+*/
+
+#define ll long long
+#define INF 987654321
+
+int N;
+vector<ll> arr; // i번째 사면체
+vector<ll> dp(300001, INF); // i개가 주어질 때 최소 사면체의 수
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    cin >> N;
+
+    arr.push_back(1);
+
+    int tri = 1; // i번 째 정삼각형
+    int idx = 2;
+
+    while (arr.back() + tri + idx <= N) {
+        tri += idx;
+        arr.push_back(arr.back() + tri);
+        idx++;
+    }
+
+    dp[0] = 0;
+
+    for (int i = 0; i < arr.size(); i++) {
+        dp[arr[i]] = 1; // i번째 사면체는 1개로 만들 수 있음
+
+        for (int j = arr[i]; j <= N; j++) {
+            dp[j] = min(dp[j], dp[j - arr[i]] + 1);
+        }
+    }
+
+    cout << dp[N] << "\n";
+}
+

--- a/problems/week08/김민선/BOJ2876_그래픽스 퀴즈.cpp
+++ b/problems/week08/김민선/BOJ2876_그래픽스 퀴즈.cpp
@@ -1,0 +1,54 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+/*
+    - 8ms
+    - 지목한 학생들에게 모두 같은 등급을 줌
+        - 다만 학생이 원래 받을 등급을 주는 거임
+    - 한 등급만 줄 수 있으므로 연속으로 같은 등급을 줄 수 있는 학생 수를 구함
+*/
+
+int N;
+int arr[100001][6] = {0, };
+int max_cnt[6] = {0, };
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    cin >> N;
+
+    for (int i = 1; i <= N; i++) {
+        int a, b;
+        cin >> a >> b;
+
+        arr[i][a] = arr[i - 1][a] + 1;
+        arr[i][b] = arr[i - 1][b] + 1;
+
+        for (int j = 1; j <= 5; j++) {
+            if (j == a || j == b) {
+                continue;
+            }
+
+            arr[i][j] = 0;
+        }
+
+        max_cnt[a] = max(max_cnt[a], arr[i][a]);
+        max_cnt[b] = max(max_cnt[b], arr[i][b]);
+    }
+
+    int max_student = 0;
+    int grade = 0;
+
+    for (int i = 1; i <= 5; i++) {
+        if (max_cnt[i] > max_student) {
+            max_student = max_cnt[i];
+            grade = i;
+        }
+    }
+
+    cout << max_student << " " << grade << "\n";
+
+    return 0;
+}

--- a/problems/week08/김민선/SFT7369_나무 수확.cpp
+++ b/problems/week08/김민선/SFT7369_나무 수확.cpp
@@ -1,0 +1,60 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+/*
+    - dp[x][y][z] x, y일 때 최대 수확량 / z: 스프링 쿨러 사용 여부
+    - 스프링 쿨러 사용 여부에 따라 dp[x][y] 값이 정해짐
+    - 스프링 쿨러 사용 x
+        - dp[x][y][0] = max(dp[x][y][0], dp[nx][ny][0] + arr[nx][ny])    
+            - 사용 안한 위, 왼쪽 값 중 큰 값 + 현재 값
+    - 스프링 쿨러 사용 o
+        - dp[x][y][1] = max(dp[x][y][1], dp[nx][ny][1] + arr[nx][ny])
+            - 사용한 위, 왼쪽 값 중 큰 값 + 현재 값
+        - dp[x][y][1] = max(dp[x][y][1], dp[nx][ny][0] + arr[nx][ny] * 2)
+            - 사용 안한 위, 왼쪽 값 중 큰 값 + 현재 값 * 2
+*/
+
+int N;
+int arr[1001][1001] = {0, };
+int dp[1001][1001][2] = {0, }; // x, y일 때 최대 수확량 / 0: 스프링 쿨러 사용 x, 1: 스프링 쿨러 사용 o
+int dx[] = {1, 0};
+int dy[] = {0, 1};
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    cin >> N;
+
+    for (int i = 1; i <= N; i++) {
+        for (int j = 1; j <= N; j++) {
+            cin >> arr[i][j];
+        }
+    }
+
+    dp[1][1][1] = arr[1][1] * 2;
+    dp[1][1][0] = arr[1][1];
+
+    for (int y = 1; y <= N; y++) {
+        for (int x = 1; x <=N; x++) {
+            for (int i = 0; i < 2; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if (nx > N || ny > N) {
+                    continue;
+                }
+                
+                dp[nx][ny][0] = max(dp[nx][ny][0], dp[x][y][0] + arr[nx][ny]);
+                dp[nx][ny][1] = max(dp[nx][ny][1], dp[x][y][1] + arr[nx][ny]);
+                dp[nx][ny][1] = max(dp[nx][ny][1], dp[x][y][0] + arr[nx][ny] * 2);
+            }
+        }
+    }   
+
+
+    cout << dp[N][N][1] << "\n";
+
+    return 0;
+}


### PR DESCRIPTION
# SFT 7369 나무 수확
## 접근 방식
- dp[x][y][z] x, y일 때 최대 수확량 / z: 스프링 쿨러 사용 여부
    - 스프링 쿨러 사용 여부에 따라 dp[x][y] 값이 정해짐
    - 스프링 쿨러 사용 x
        - dp[x][y][0] = max(dp[x][y][0], dp[nx][ny][0] + arr[nx][ny])    
            - 사용 안한 위, 왼쪽 값 중 큰 값 + 현재 값
    - 스프링 쿨러 사용 o
        - dp[x][y][1] = max(dp[x][y][1], dp[nx][ny][1] + arr[nx][ny])
            - 사용한 위, 왼쪽 값 중 큰 값 + 현재 값
        - dp[x][y][1] = max(dp[x][y][1], dp[nx][ny][0] + arr[nx][ny] * 2)
            - 사용 안한 위, 왼쪽 값 중 큰 값 + 현재 값 * 2
# BOJ 1149 RGB거리
## 접근 방식
- dp[i][색상]: i번 째 집을 색상으로 칠했을 때의 최소 비용
- dp[i][색상] = min(dp[i - 1][다른 색상1], dp[i - 1][다른 색상2]) + 현재 색상
# BOJ 1660 캡틴 이다솜
## 접근 방식
- 사면체는 정삼각형의 합으로 만들 수 있음
- i 번째 사면체 구해두고
- dp[i]: i개가 주어질 때 최소 사면체의 수
- dp[i] = min(dp[i], dp[i - i 번째 사면체 포탄 갯수] + 1)
# BOJ 2876 그래픽스 퀴즈
## 접근 방식
- 지목한 학생들에게 모두 같은 등급을 줌
    - 다만 학생이 원래 받을 등급을 주는 거임
- 한 등급만 줄 수 있으므로 연속으로 같은 등급을 줄 수 있는 학생 수를 구함
- 배열 사용해 등급별 연속으로 점수를 받을 수 있는 학생 수 저장
# STF 7699 Hanyang Cherry Picking Contest
- 현우님 풀이 보고 이해는 하였으나
- 나중에 실력이 더 늘었을 때나 시간이 넉넉할 때 다시 풀겠습니다.