### PR TITLE
[정현우] 10주차 문제풀이

### DIFF
--- a/problems/week10/정현우/BOJ1051_숫자정사각형.java
+++ b/problems/week10/정현우/BOJ1051_숫자정사각형.java
@@ -1,0 +1,51 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 1051 숫자 정사각형
+ * - 64 ms
+ * - 브루트포스
+ * - 만들 수 있는 가장 큰 정사각형부터
+ * - 크기 줄여가며 탐색
+ * - 정사각형 발견 시 크기 출력
+ * */
+public class BOJ1051_숫자정사각형 {
+    public static void main(String[] args) throws IOException {
+        int n;
+        int m;
+        int i;
+        int j;
+        int row;
+        int col;
+        int size;
+        char ch;
+        char[][] map;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new char[n][++m];
+        for (i = 0; i < n; i++) { // 직사각형 입력
+            br.read(map[i], 0, m);
+        }
+        m--;
+        for (size = Math.min(n, m) - 1; size >= 0; size--) { // size : 크기 - 1
+            row = n - size; // 탐색할 행 한계
+            for (i = 0; i < row; i++) {
+                col = m - size; // 탐색할 열 한계
+                for (j = 0; j < col; j++) {
+                    ch = map[i][j]; // 정사각형의 왼쪽 위
+                    if (map[i + size][j] == ch && map[i][j + size] == ch && map[i + size][j + size] == ch) {
+                        System.out.print((size + 1) * (size + 1)); // 정사각형 발견 시 크기 출력
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/problems/week10/정현우/BOJ1283_단축키지정.java
+++ b/problems/week10/정현우/BOJ1283_단축키지정.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 1283 단축키 지정
+ * - 64 ms
+ * - 문자열
+ * - 첫 글자가 지정이 안 되어 있으면 단축키 지정
+ * - 공백 뒤 글자가 지정이 안 되어 있으면 단축키 지정
+ * - 공백이 아닌 글자가 지정이 안 되어 있으면 단축키 지정
+ * - 해당 사항 없으면 그대로 출력
+ * */
+public class BOJ1283_단축키지정 {
+    private static final int SIZE = 57;
+    private static final int ALPHA = 26;
+    private static final char LOWER = 'a';
+    private static final char UPPER = 'A';
+    private static final char OPEN = '[';
+    private static final char CLOSE = ']';
+    private static final char SPACE = ' ';
+    private static final char LINE_BREAK = '\n';
+
+    private static int len;
+    private static char[] str;
+    private static char[] result;
+    private static boolean[] visited;
+    private static StringBuilder sb;
+
+    private static final boolean isVisited(char ch) {
+        if (ch < LOWER) {
+            ch -= UPPER;
+        } else {
+            ch -= LOWER;
+        }
+        if (visited[ch]) {
+            return true;
+        } else {
+            visited[ch] = true;
+            return false;
+        }
+    }
+
+    private static final void prefix(int idx) {
+        System.arraycopy(str, 0, result, 0, idx);
+        result[idx] = OPEN;
+        result[idx + 1] = str[idx];
+        result[idx + 2] = CLOSE;
+        System.arraycopy(str, idx + 1, result, idx + 3, len - 1 - idx);
+        result[len + 2] = LINE_BREAK;
+        sb.append(result, 0, len + 3);
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int i;
+        BufferedReader br;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        visited = new boolean[ALPHA];
+        result = new char[SIZE];
+        sb = new StringBuilder();
+        loop:
+        while (n-- > 0) {
+            str = br.readLine().toCharArray();
+            len = str.length;
+            if (!isVisited(str[0])) { // 첫 글자가 지정이 안 되어 있으면
+                prefix(0); // 단축키 지정
+                continue;
+            }
+            for (i = 1; i < len; i++) { // 공백 뒤 글자가 지정이 안 되어 있으면
+                if (str[i] == SPACE && !isVisited(str[i + 1])) {
+                    prefix(i + 1); // 단축키 지정
+                    continue loop;
+                }
+            }
+            for (i = 0; i < len; i++) { // 공백이 아닌 글자가 지정이 안 되어 있으면
+                if (str[i] != SPACE && !isVisited(str[i])) {
+                    prefix(i); // 단축키 지정
+                    continue loop;
+                }
+            }
+            sb.append(str).append(LINE_BREAK); // 해당 사항 없으면 그대로 출력
+        }
+        System.out.print(sb.toString());
+    }
+}

--- a/problems/week10/정현우/BOJ17281_야구.java
+++ b/problems/week10/정현우/BOJ17281_야구.java
@@ -1,0 +1,118 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 17281 ⚾
+ * - 336 ms
+ * - 순열, 비트마스킹
+ * - 4번 타자(1번 선수)를 제외하고 순열 돌리면서 점수 계산
+ * - [ 3루 - 2루 - 1루 - 홈(타자) ] 주자 정보를
+ * -   runners 에 비트 4 개로 저장
+ * - 안타, 2루타, 3루타, 홈런 마다 홈으로 들어오는 베이스 위치
+ * -   AND 배열에 각각 저장
+ * - 0 ~ 15 의 비트카운트 정보 SCORES 배열에 저장
+ * - 아웃일 경우
+ * -   아웃 카운트 증가
+ * -   3 아웃이면 다음 이닝, 아웃 카운트와 주자 정보 초기화
+ * - 안타, 2루타, 3루타, 홈런을 칠 경우
+ * -   SCORES[runners & AND[(결과)]] 만큼 점수 증가
+ * -   주자 정보는 runners << (결과)) | 1(다음 타자) 로 변화
+ * */
+public class BOJ17281_야구 {
+    private static final int OUT = 0;
+    private static final int SIZE = 9;
+    private static final int LINE = SIZE << 1;
+    private static final int DIFF = '0';
+    private static final int CLEAN_UP = 3;
+    private static final int MAX_OUT_CNT = 3;
+    private static final int[] AND = {0, 8, 12, 14, 15}; // 안타, 2루타, 3루타, 홈런 마다 홈으로 들어오는 주자 위치
+    private static final int[] SCORES = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4}; // 0 ~ 15 비트카운트
+
+    private static int n;
+    private static int max;
+    private static int[] batters;
+    private static int[][] innings;
+    private static boolean[] visited;
+
+    private static final int play(int[] batters) {
+        int score;
+        int inning;
+        int batter;
+        int outCnt;
+        int result;
+        int runners;
+        int batterIdx;
+        int[] results;
+
+        score = 0;
+        inning = 0;
+        outCnt = 0;
+        runners = 1;
+        batterIdx = 0; // 타자 순회
+        results = innings[0]; // 첫 이닝 정보
+        for(batter = batters[0];; batter = batters[batterIdx = (batterIdx + 1) % SIZE]) {
+            if ((result = results[batter]) == OUT) { // 아웃
+                if (++outCnt == MAX_OUT_CNT) { // 3 아웃
+                    if (++inning == n) { // 모든 이닝 종료
+                        break;
+                    }
+                    outCnt = 0; // 아웃 카운트 초기화
+                    runners = 1; // 주자 정보 초기화
+                    results = innings[inning]; // 다음 이닝 정보
+                }
+            } else { // 안타, 2루타, 3루타, 홈런
+                score += SCORES[runners & AND[result]]; // 점수 증가
+                runners = runners << result | 1; // 주자 정보 업데이트
+            }
+        }
+        return score;
+    }
+
+    private static final void permu(int depth) { // 순열
+        int i;
+
+        if (depth == SIZE) { // 선수 배정 완료
+            max = Math.max(max, play(batters)); // 점수 계산
+            return;
+        }
+        if (depth == CLEAN_UP) { // 4번 타자
+            permu(depth + 1); // 건너뛰기
+            return;
+        }
+        for (i = 1; i < SIZE; i++) {
+            if (visited[i]) { // 이미 배정한 선수
+                continue;
+            }
+            visited[i] = true; // 방문 처리
+            batters[depth] = i; // 선수 배정
+            permu(depth + 1); // 다음 순번으로 이동
+            visited[i] = false; // 원상 복구
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        int i;
+        int j;
+        int[] results;
+        char[] input;
+        BufferedReader br;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        input = new char[LINE];
+        innings = new int[n][SIZE];
+        for (i = 0; i < n; i++) { // 이닝별 결과 입력
+            br.read(input, 0, LINE);
+            results = innings[i];
+            for (j = 0; j < SIZE; j++) {
+                results[j] = input[j << 1] - DIFF;
+            }
+        }
+        max = 0;
+        batters = new int[SIZE];
+        visited = new boolean[SIZE];
+        permu(0); // 순열
+        System.out.print(max); // 최대 점수 출력
+    }
+}

--- a/problems/week10/정현우/BOJ27527_배너걸기.java
+++ b/problems/week10/정현우/BOJ27527_배너걸기.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 27527 배너 걸기
+ * - 288 ms
+ * - 큐
+ * - 각 숫자별 현재 큐에 존재하는 개수 카운트
+ * - 큐에 새로운 숫자를 넣고 처음 숫자를 빼면서
+ * - 큐 크기 M 으로 유지
+ * - 특정 숫자가 ⌈9 * m / 10⌉ 개에 도달하면
+ * - 배너 걸기 가능
+ * */
+public class BOJ27527_배너걸기 {
+    private static final int SIZE = 1_000_001;
+    private static final char[] YES = {'Y', 'E', 'S'};
+    private static final char[] NO = {'N', 'O'};
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int m;
+        int i;
+        int num;
+        int thr;
+        int[] cnt;
+        ArrayDeque<Integer> q;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        thr = (9 * (m + 1)) / 10; // ⌈9 * m / 10⌉
+        q = new ArrayDeque<>(m);
+        cnt = new int[SIZE]; // 각 숫자별 현재 큐에 존재하는 개수 카운트
+        st = new StringTokenizer(br.readLine(), " ", false);
+        for (i = 1; i < m; i++) { // 첫 M - 1 개 숫자 삽입
+            num = Integer.parseInt(st.nextToken());
+            if (++cnt[num] == thr) { // 특정 숫자가 ⌈9 * m / 10⌉ 개에 도달하면
+                System.out.print(YES); // 배너 걸기 가능
+                return;
+            }
+            q.addLast(num);
+        }
+        for (--i; i < n; i++) {
+            num = Integer.parseInt(st.nextToken());
+            if (++cnt[num] == thr) { // 특정 숫자가 ⌈9 * m / 10⌉ 개에 도달하면
+                System.out.print(YES); // 배너 걸기 가능
+                return;
+            }
+            q.addLast(num); // 큐에 삽입하면 큐 크기 M
+            cnt[q.pollFirst()]--; // 처음 숫자를 빼기
+        }
+        System.out.print(NO); // 배너 걸기 불가능
+    }
+}

--- a/problems/week10/정현우/SFT6246_순서대로방문하기.java
+++ b/problems/week10/정현우/SFT6246_순서대로방문하기.java
@@ -1,0 +1,91 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : SFT 6246 순서대로 방문하기
+ * - 71 ms
+ * - DFS
+ * - map 1 차원 변환
+ * - 방문해야 하는 위치에 순번 부여
+ * - 현재 찾는 순번보다 큰 위치는 방문 하지 않음
+ * - 현재 찾는 순번과 일치하면 다음 순번 찾기
+ * - 마지막 위치 찾으면 경로 개수 1 증가
+ * */
+public class SFT6246_순서대로방문하기 {
+    private static final int WALL = '1';
+
+    private static int col;
+    private static int cnt;
+    private static int end;
+    private static int[] map;
+
+    private static final void dfs(int pos, int num) {
+        int temp;
+
+        if (map[pos] > num) { // 현재 찾는 순번보다 큰 위치
+            return; // 방문 하지 않음
+        }
+        if (pos == end) { // 마지막 위치 찾으면
+            cnt++; // 경로 개수 1 증가
+            return;
+        }
+        if (map[pos] == num) { // 현재 찾는 순번과 일치
+            num++; // 다음 순번 찾기
+        }
+        temp = map[pos];
+        map[pos] = WALL; // 방문 처리
+        dfs(pos - col, num); // 4방 탐색
+        dfs(pos + 1, num);
+        dfs(pos + col, num);
+        dfs(pos - 1, num);
+        map[pos] = temp; // 원상 복구
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int m;
+        int i;
+        int j;
+        int thr;
+        int start;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        col = n + 2;
+        thr = (n + 1) * col;
+        map = new int[col * col]; // map 1 차원 변환
+        for (i = 1; i <= n; i++) { // 위쪽 벽 세우기
+            map[i] = WALL;
+        }
+        for (i = col; i < thr; i += col) {
+            map[i] = WALL; // 왼쪽 벽 세우기
+            for (j = 1; j <= n; j++) {
+                if (br.read() == WALL) { // 벽 위치
+                    map[i + j] = WALL;
+                }
+                br.read();
+            }
+            map[i + j] = WALL; // 오른쪽 벽 세우기
+        }
+        System.arraycopy(map, 1, map, thr + 1, n); // 아래쪽 벽 세우기
+        m--;
+        st = new StringTokenizer(br.readLine(), " ", false); // 시작점
+        start = Integer.parseInt(st.nextToken()) * col + Integer.parseInt(st.nextToken());
+        for (i = 1; i < m; i++) {
+            st = new StringTokenizer(br.readLine(), " ", false); // 순번 부여
+            map[Integer.parseInt(st.nextToken()) * col + Integer.parseInt(st.nextToken())] = i;
+        }
+        st = new StringTokenizer(br.readLine(), " ", false); // 끝점
+        end = Integer.parseInt(st.nextToken()) * col + Integer.parseInt(st.nextToken());
+        map[end] = (char) m; // 마지막 순번
+        cnt = 0;
+        dfs(start, 1); // DFS
+        System.out.print(cnt); // 경로 개수 출력
+    }
+}


### PR DESCRIPTION
## [BOJ 17281 ⚾](https://github.com/Algo-Study-2409/algo-study-2409/commit/1d1a51b3548703c51fef022ccfe1575b550c1fb6) 

- 336 ms
- 순열, 비트마스킹
### 풀이
4번 타자(1번 선수)를 제외하고 순열 돌리면서 점수 계산
[ 3루 - 2루 - 1루 - 홈(타자) ] 주자 정보를
&nbsp;&nbsp;runners 에 비트 4 개로 저장
안타, 2루타, 3루타, 홈런 마다 홈으로 들어오는 베이스 위치
&nbsp;&nbsp;AND 배열에 각각 저장
0 ~ 15 의 비트카운트 정보 SCORES 배열에 저장
아웃일 경우
&nbsp;&nbsp;아웃 카운트 증가
&nbsp;&nbsp;3 아웃이면 다음 이닝, 아웃 카운트와 주자 정보 초기화
안타, 2루타, 3루타, 홈런을 칠 경우
&nbsp;&nbsp;SCORES[runners & AND[(결과)]] 만큼 점수 증가
&nbsp;&nbsp;주자 정보는 runners << (결과)) | 1(다음 타자) 로 변화

## [BOJ 1283 단축키 지정](https://github.com/Algo-Study-2409/algo-study-2409/commit/a3d15a282973cc5a617ebfdd85c84a57ca5aa238) 

- 64 ms
- 문자열
### 풀이
첫 글자가 지정이 안 되어 있으면 단축키 지정
공백 뒤 글자가 지정이 안 되어 있으면 단축키 지정
공백이 아닌 글자가 지정이 안 되어 있으면 단축키 지정
해당 사항 없으면 그대로 출력

## [BOJ 27527 배너 걸기](https://github.com/Algo-Study-2409/algo-study-2409/commit/3b2d5d0d49242e3e114b3a64302c9ba14befb16f) 

- 288 ms
- 큐
### 풀이
각 숫자별 현재 큐에 존재하는 개수 카운트
큐에 새로운 숫자를 넣고 처음 숫자를 빼면서
큐 크기 M 으로 유지
특정 숫자가 ⌈9 * m / 10⌉ 개에 도달하면
배너 걸기 가능

## [BOJ 1051 숫자 정사각형](https://github.com/Algo-Study-2409/algo-study-2409/commit/8649b35110d3e20426a8ce2e75dd769c8c9fa4de) 

- 64 ms
- 브루트포스
### 풀이
만들 수 있는 가장 큰 정사각형부터
크기 줄여가며 탐색
정사각형 발견 시 크기 출력

## [SFT 6246 순서대로 방문하기](https://github.com/Algo-Study-2409/algo-study-2409/commit/5c27209b00c22bda98e3d86b1a93f69f067d62f5) 

- 71 ms
- DFS
### 풀이
map 1 차원 변환
방문해야 하는 위치에 순번 부여
현재 찾는 순번보다 큰 위치는 방문 하지 않음
현재 찾는 순번과 일치하면 다음 순번 찾기
마지막 위치 찾으면 경로 개수 1 증가