### PR TITLE
[정현우] 11주차 문제풀이

### DIFF
--- a/problems/week11/정현우/BOJ12054_IPAddressSummarizationSmall.java
+++ b/problems/week11/정현우/BOJ12054_IPAddressSummarizationSmall.java
@@ -1,0 +1,112 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 12054 IP Address Summarization (Small)
+ * - 76 ms
+ * - 트라이, DFS
+ * - IP 주소 32 비트 정수로 전환
+ * - 앞에서부터 P 개의 비트만 트라이에 삽입
+ * - P 개 이후 끝 표시
+ * - 0, 1 두 자식 노드가 모두 끝이면 현재 노드도 끝 표시
+ * - 트라이에 들어있는 비트들 주소로 변환하여 출력
+ * - 하나의 트라이에서 테스트케이스 별로 노드 관리
+ * */
+public class BOJ12054_IPAddressSummarizationSmall {
+    private static final int START = 1 << 31;
+    private static final int MOD = (1 << 8) - 1;
+    private static final char DOT = '.';
+    private static final char SLASH = '/';
+    private static final char LINE_BREAK = '\n';
+    private static final char[] PREFIX = "Case #".toCharArray();
+    private static final char[] SUFFIX = {':', LINE_BREAK};
+    private static final String DELIM = "./";
+
+    private static final class Trie {
+        private int time;
+        private int output;
+        private Trie zero;
+        private Trie one;
+
+        final void insert(int addr, int bit, int end) {
+            this.time = testCase; // 노드 시간 표시
+            if (bit == end) {
+                output = testCase; // P 개 이후 끝 표시
+                return;
+            }
+            if ((addr & bit) == 0) { // 비트 0
+                if (zero == null) {
+                    zero = new Trie();
+                }
+                zero.insert(addr, bit >>> 1, end); // 다음 비트
+            } else { // 비트 1
+                if (one == null) {
+                    one = new Trie();
+                }
+                one.insert(addr, bit >>> 1, end); // 다음 비트
+            }
+            if (zero != null && one != null && zero.output == testCase && one.output == testCase) {
+                output = testCase; // 0, 1 두 자식 노드가 모두 끝이면 현재 노드도 끝 표시
+            }
+        }
+
+        final void print(int num, int depth) {
+            if (output == testCase) { // 끝 노드
+                num <<= 32 - depth; // 32 비트 마저 0 으로 채우기
+                sb.append((num >>> 24) & MOD).append(DOT)
+                        .append((num >>> 16) & MOD).append(DOT)
+                        .append((num >>> 8) & MOD).append(DOT)
+                        .append(num & MOD).append(SLASH)
+                        .append(depth).append(LINE_BREAK); // 32 비트 정수를 주소로 변환
+                return;
+            }
+            depth++;
+            if (zero != null && zero.time == testCase) {
+                zero.print(num << 1, depth); // 0 추가
+            }
+            if (one != null && one.time == testCase) {
+                one.print(num << 1 | 1, depth); // 1 추가
+            }
+        }
+    }
+
+    private static int testCase;
+    private static Trie trie;
+    private static StringBuilder sb;
+    private static BufferedReader br;
+
+    private static final void solution() throws IOException {
+        int n;
+        int p;
+        int addr;
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        while (n-- > 0) {
+            st = new StringTokenizer(br.readLine(), DELIM, false);
+            addr = Integer.parseInt(st.nextToken()) << 24
+                    | Integer.parseInt(st.nextToken()) << 16
+                    | Integer.parseInt(st.nextToken()) << 8
+                    | Integer.parseInt(st.nextToken()); // IP 주소 32 비트 정수로 전환
+            p = Integer.parseInt(st.nextToken());
+            trie.insert(addr, START, START >>> p); // 트라이에 삽입
+        }
+        trie.print(0, 0); // 트라이 출력
+    }
+
+    public static void main(String[] args) throws IOException {
+        int t;
+
+        trie = new Trie();
+        br = new BufferedReader(new InputStreamReader(System.in));
+        t = Integer.parseInt(br.readLine());
+        sb = new StringBuilder();
+        for (testCase = 1; testCase <= t; testCase++) {
+            sb.append(PREFIX).append(testCase).append(SUFFIX);
+            solution();
+        }
+        System.out.print(sb.toString());
+    }
+}

--- a/problems/week11/정현우/BOJ14426_접두사찾기.java
+++ b/problems/week11/정현우/BOJ14426_접두사찾기.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 14426 접두사 찾기
+ * - 292 ms
+ * - 트라이
+ * - N 개 문자열 트라이에 삽입
+ * - M 개 문자열 트라이에서 탐색
+ * - 트라이에 존재하는 개수 출력
+ * */
+public class BOJ14426_접두사찾기 {
+    private static final int DIFF = 'a';
+    private static final int ALPHABET_SIZE = 26;
+
+    private static final class Trie {
+        Trie[] next;
+
+        Trie() {
+            next = new Trie[ALPHABET_SIZE];
+        }
+
+        final void insert(char[] word) {
+            int idx;
+            Trie curr;
+
+            curr = this;
+            for (char ch : word) {
+                idx = ch - DIFF;
+                if (curr.next[idx] == null) {
+                    curr.next[idx] = new Trie();
+                }
+                curr = curr.next[idx];
+            }
+        }
+
+        final boolean search(char[] word) {
+            int idx;
+            Trie curr;
+
+            curr = this;
+            for (char ch : word) {
+                idx = ch - DIFF;
+                if (curr.next[idx] == null) { // 트라이에 존재하지 않음
+                    return false;
+                }
+                curr = curr.next[idx];
+            }
+            return true; // 트라이에 존재
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        int m;
+        int cnt;
+        Trie trie;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        st = new StringTokenizer(br.readLine(), " ", false);
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        trie = new Trie();
+        while (n-- > 0) { // N 개 문자열 트라이에 삽입
+            trie.insert(br.readLine().toCharArray());
+        }
+        cnt = 0;
+        while (m-- > 0) { // M 개 문자열 트라이에서 탐색
+            if (trie.search(br.readLine().toCharArray())) {
+                cnt++; // 트라이에 존재하는 개수 카운트
+            }
+        }
+        System.out.print(cnt);
+    }
+}

--- a/problems/week11/정현우/BOJ14725_개미굴.java
+++ b/problems/week11/정현우/BOJ14725_개미굴.java
@@ -1,0 +1,89 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.StringTokenizer;
+
+/**
+ * 정현우 : BOJ 14725 개미굴
+ * - 92 ms
+ * - 트라이, DFS
+ * - 각 방을 노드로 각 StringTokenizer 를 트라이에 삽입
+ * - TreeMap 으로 정렬 유지
+ * - 트라이의 모든 노드를 DFS 출력하면서
+ * - depth 만큼 "--" 추가
+ * */
+public class BOJ14725_개미굴 {
+    private static final int MAX_K = 15;
+    private static final char HYPHEN = '-';
+    private static final char LINE_BREAK = '\n';
+    private static final char[][] INDENTS = initIndent();
+
+    private static final class Trie {
+        private TreeMap<String, Trie> map;
+
+        Trie() {
+            map = new TreeMap<>();
+        }
+
+        final void insert(StringTokenizer st) {
+            Trie curr;
+            Trie next;
+            String str;
+
+            curr = this;
+            while (st.hasMoreTokens()) { // StringTokenizer 를 트라이에 삽입
+                if ((next = curr.map.get(str = st.nextToken())) == null) {
+                    curr.map.put(str, next = new Trie());
+                }
+                curr = next;
+            }
+        }
+
+        final void print(int level) { // depth 만큼 "--" 추가하여 출력
+            for (Entry<String, Trie> entry : map.entrySet()) {
+                sb.append(INDENTS[level]).append(entry.getKey()).append(LINE_BREAK);
+                entry.getValue().print(level + 1);
+            }
+        }
+    }
+
+    private static StringBuilder sb;
+
+    private static final char[][] initIndent() {
+        int i;
+        char[][] indents;
+
+        indents = new char[MAX_K + 1][]; // depth 별 indent 생성
+        indents[MAX_K] = new char[MAX_K << 1];
+        for (i = 0; i < MAX_K; i++) { // 가장 깊은 indent
+            indents[MAX_K][i << 1] = HYPHEN;
+            indents[MAX_K][i << 1 | 1] = HYPHEN;
+        }
+        for (i = 0; i < MAX_K; i++) { // 나머지 indent
+            indents[i] = new char[i << 1];
+            System.arraycopy(indents[MAX_K], 0, indents[i], 0, i << 1);
+        }
+        return indents;
+    }
+
+    public static void main(String[] args) throws IOException {
+        int n;
+        Trie trie;
+        BufferedReader br;
+        StringTokenizer st;
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        trie = new Trie();
+        while (n-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            st.nextToken(); // 숫자 무시
+            trie.insert(st); // 각 StringTokenizer 를 트라이에 삽입
+        }
+        sb = new StringBuilder();
+        trie.print(0); // 트라이의 노드들 DFS 출력
+        System.out.print(sb.toString());
+    }
+}

--- a/problems/week11/정현우/BOJ5052_전화번호목록.java
+++ b/problems/week11/정현우/BOJ5052_전화번호목록.java
@@ -1,0 +1,89 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 정현우 : BOJ 5052 전화번호 목록
+ * - 264 ms
+ * - 트라이
+ * - 전화번호를 트라이에 삽입하면서 확인
+ * - 이미 존재하는 번호의 끝에 도달하면 일관성 없음
+ * - 삽입하는 전화전호의 끝이 다른 번호에 포함되면 일관성 없음
+ * - 하나의 트라이에서 테스트케이스 별로 노드 관리
+ * */
+public class BOJ5052_전화번호목록 {
+    private static final int DIFF = '0';
+    private static final int DIGITS = 10;
+    private static final char[] YES = {'Y', 'E', 'S', '\n'};
+    private static final char[] NO = {'N', 'O', '\n'};
+
+    private static int testCase;
+    private static Trie trie;
+    private static BufferedReader br;
+
+    private static final class Trie {
+        int time;
+        int output;
+        Trie[] next;
+
+        Trie() {
+            next = new Trie[DIGITS];
+        }
+
+        boolean contains(char[] str) {
+            int i;
+            int idx;
+            int len;
+            Trie curr;
+
+            len = str.length;
+            curr = this;
+            for (i = 0; i < len; i++) {
+                if (curr.output == testCase) { // 이미 존재하는 번호의 끝에 도달
+                    return true;
+                }
+                curr.time = testCase; // 노드 시간 표시
+                idx = str[i] - DIFF;
+                if (curr.next[idx] == null) {
+                    curr.next[idx] = new Trie();
+                }
+                curr = curr.next[idx];
+            }
+            if (curr.time == testCase) { // 삽입하는 전화전호의 끝이 다른 번호에 포함
+                return true;
+            }
+            curr.time = testCase; // 노드 시간 표시
+            curr.output = testCase; // 전화번호 끝 표시
+            return false;
+        }
+    }
+
+    private static final boolean solution() throws IOException {
+        int n;
+
+        n = Integer.parseInt(br.readLine());
+        while (n-- > 0) {
+            if (trie.contains(br.readLine().toCharArray())) { // 포함 확인
+                while (n-- > 0) { // 나머지 입력 건너뛰기
+                    br.readLine();
+                }
+                return false; // 일관성 없음
+            }
+        }
+        return true; // 일관성 있음
+    }
+
+    public static void main(String[] args) throws IOException {
+        int t;
+        StringBuilder sb;
+
+        trie = new Trie();
+        br = new BufferedReader(new InputStreamReader(System.in));
+        t = Integer.parseInt(br.readLine());
+        sb = new StringBuilder();
+        for (testCase = 1; testCase <= t; testCase++) {
+            sb.append(solution() ? YES : NO);
+        }
+        System.out.print(sb.toString());
+    }
+}

--- a/problems/week11/정현우/PGS60060_가사검색.java
+++ b/problems/week11/정현우/PGS60060_가사검색.java
@@ -1,0 +1,135 @@
+/**
+ * 정현우 : PGS 60060 가사 검색
+ * - 396.52 ms
+ * - 트라이
+ * - 단어 길이별 정방향 트라이, 역방향 트라이 생성
+ * - 트라이 노드별로 하위 단어 개수 저장
+ * - '?' 가 뒤쪽에 올 경우 정방향 트라이,
+ * - '?' 가 앞쪽에 올 경우 역방향 트라이에서 탐색
+ * */
+public class PGS60060_가사검색 {
+    private static final int FAIL = 0;
+    private static final int DIFF = 'a';
+    private static final int MAX_WORD_LEN = 10_001;
+    private static final int ALPHABET_SIZE = 26;
+    private static final char WILD_CARD = '?';
+
+    private static final class Trie {
+        int cnt;
+        Trie[] next;
+
+        Trie() {
+            next = new Trie[ALPHABET_SIZE];
+        }
+
+        void insertForward(char[] word, int len) {
+            int i;
+            int idx;
+            Trie curr;
+
+            curr = this;
+            for (i = 0; i < len; i++) { // 정방향 삽입
+                curr.cnt++; // 하위 단어 개수 + 1
+                idx = word[i] - DIFF;
+                if (curr.next[idx] == null) {
+                    curr.next[idx] = new Trie();
+                }
+                curr = curr.next[idx];
+            }
+            curr.cnt++;
+        }
+
+        void insertBackward(char[] word, int len) {
+            int i;
+            int idx;
+            Trie curr;
+
+            curr = this;
+            for (i = len - 1; i >= 0; i--) { // 역방향 삽입
+                curr.cnt++; // 하위 단어 개수 + 1
+                idx = word[i] - DIFF;
+                if (curr.next[idx] == null) {
+                    curr.next[idx] = new Trie();
+                }
+                curr = curr.next[idx];
+            }
+            curr.cnt++;
+        }
+
+        int searchForward(char[] word, int len) {
+            int i;
+            int idx;
+            Trie curr;
+
+            curr = this;
+            for (i = 0; i < len; i++) { // 정방향 탐색
+                if (word[i] == WILD_CARD) { // '?' 도달
+                    break;
+                }
+                idx = word[i] - DIFF;
+                if (curr.next[idx] == null) { // 일치하는 단어가 없음
+                    return FAIL; // 0 반환
+                }
+                curr = curr.next[idx];
+            }
+            return curr.cnt;
+        }
+
+        int searchBackward(char[] word, int len) {
+            int i;
+            int idx;
+            Trie curr;
+
+            curr = this;
+            for (i = len - 1; i >= 0; i--) { // 역방향 탐색
+                if (word[i] == WILD_CARD) { // '?' 도달
+                    break;
+                }
+                idx = word[i] - DIFF;
+                if (curr.next[idx] == null) { // 일치하는 단어가 없음
+                    return FAIL; // 0 반환
+                }
+                curr = curr.next[idx];
+            }
+            return curr.cnt;
+        }
+    }
+
+    public int[] solution(String[] words, String[] queries) {
+        int i;
+        int len;
+        int size;
+        int[] ans;
+        char[] arr;
+        Trie[] forward;
+        Trie[] backward;
+
+        forward = new Trie[MAX_WORD_LEN]; // 단어 길이별 정방향 트라이
+        backward = new Trie[MAX_WORD_LEN]; // 단어 길이별 역방향 트라이
+        for (i = 1; i < MAX_WORD_LEN; i++) {
+            forward[i] = new Trie();
+            backward[i] = new Trie();
+        }
+        for (String word : words) {
+            arr = word.toCharArray(); // 단어
+            len = arr.length; // 단어 길이
+            if (len >= MAX_WORD_LEN) { // 검색 키워드 최대 길이를 초과하는 단어
+                continue;
+            }
+            forward[len].insertForward(arr, len); // 정방향 트라이에 삽입
+            backward[len].insertBackward(arr, len); // 역방향 트라이에 삽입
+        }
+        size = queries.length;
+        ans = new int[size];
+        for (i = 0; i < size; i++) {
+            arr = queries[i].toCharArray(); // 검색 키워드
+            len = arr.length; // 검색 키워드 길이
+            if (arr[0] == WILD_CARD) { // '?' 가 앞쪽에 올 경우
+                ans[i] = backward[len].searchBackward(arr, len); // 역방향 트라이에서 탐색
+            } else { // '?' 가 뒤쪽에 올 경우
+                ans[i] = forward[len].searchForward(arr, len); // 정방향 트라이에서 탐색
+            }
+        }
+        return ans;
+    }
+}


### PR DESCRIPTION
## [PGS 60060 가사 검색](https://github.com/Algo-Study-2409/algo-study-2409/commit/c15607e919cf885ab74e760f3650c47637f32335) 

- 396.52 ms
- 트라이
### 풀이
단어 길이별 정방향 트라이, 역방향 트라이 생성
트라이 노드별로 하위 단어 개수 저장
'?' 가 뒤쪽에 올 경우 정방향 트라이,
'?' 가 앞쪽에 올 경우 역방향 트라이에서 탐색

## [BOJ 14426 접두사 찾기](https://github.com/Algo-Study-2409/algo-study-2409/commit/7bdf27e4c3d97f6eb206053b1c3743df5155f2d4) 

- 292 ms
- 트라이
### 풀이
N 개 문자열 트라이에 삽입
M 개 문자열 트라이에서 탐색
트라이에 존재하는 개수 출력

## [BOJ 5052 전화번호 목록](https://github.com/Algo-Study-2409/algo-study-2409/commit/049ecdb2d1f0180f0822301a27e7a9b10a6b21fa) 

- 264 ms
- 트라이
### 풀이
전화번호를 트라이에 삽입하면서 확인
이미 존재하는 번호의 끝에 도달하면 일관성 없음
삽입하는 전화전호의 끝이 다른 번호에 포함되면 일관성 없음
하나의 트라이에서 테스트케이스 별로 노드 관리

## [BOJ 12054 IP Address Summarization (Small)](https://github.com/Algo-Study-2409/algo-study-2409/commit/f1828fa5ea433f7c4ff3204d8413199a36db1c04) 

- 76 ms
- 트라이, DFS
### 풀이
IP 주소 32 비트 정수로 전환
앞에서부터 P 개의 비트만 트라이에 삽입
P 개 이후 끝 표시
0, 1 두 자식 노드가 모두 끝이면 현재 노드도 끝 표시
트라이에 들어있는 비트들 주소로 변환하여 출력
하나의 트라이에서 테스트케이스 별로 노드 관리

## [BOJ 14725 개미굴](https://github.com/Algo-Study-2409/algo-study-2409/commit/02c7ea6711ee88ba5113dfe7fd0f68219333c0cd) 

- 92 ms
- 트라이, DFS
### 풀이
각 방을 노드로 각 StringTokenizer 를 트라이에 삽입
TreeMap 으로 정렬 유지
트라이의 모든 노드를 DFS 출력하면서
depth 만큼 "--" 추가